### PR TITLE
fix: clean up dead config, add sendToC4 retry, improve setup guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.16] - 2026-02-08
+
+### Fixed
+- Removed dead config fields: `features.auto_split_messages` and `features.max_message_length` (never used, send.js uses hardcoded constant)
+- `sendToC4` now retries once after 2s on failure (was fire-and-forget)
+- `context.js`: changed `|| 10` to `?? 10` so `context_messages: 0` is respected
+- Post-upgrade migrations: stop adding dead fields, add cleanup for existing installs, add `message.context_messages` migration
+- `notifyOwnerPendingGroup` broken since beta.14: send.js path not updated when moved to scripts/ (would fail when bot is added to a new group)
+- DESIGN.md: removed phantom "Product Key" references, stale security log example, phantom "message.js" module
+- DESIGN.md: fixed c4-receive path, send.js path (root → scripts/), directory tree (added context.js, ecosystem.config.cjs), `--source` → `--channel`, added allowed_groups and message.context_messages to config docs
+- DESIGN.md: PM2 config example updated to CJS format matching actual ecosystem.config.cjs
+- README.md: updated version badge from beta.9 to beta.16
+
+### Added
+- Post-install: full Telegram Bot Setup Checklist (BotFather link, proxy hint, owner binding note)
+- SKILL.md: added Environment Variables section documenting `TELEGRAM_PROXY_URL`
+
+---
+
 ## [0.1.0-beta.15] - 2026-02-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zylos-telegram
 
-[![Version](https://img.shields.io/badge/version-0.1.0--beta.9-blue.svg)](https://github.com/zylos-ai/zylos-telegram/releases)
+[![Version](https://img.shields.io/badge/version-0.1.0--beta.16-blue.svg)](https://github.com/zylos-ai/zylos-telegram/releases)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
 Telegram Bot component for [Zylos Agent](https://github.com/zylos-ai/zylos-core), enabling bidirectional messaging between users and Claude via Telegram.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telegram
-version: 0.1.0-beta.15
+version: 0.1.0-beta.16
 description: Telegram Bot for user communication
 type: communication
 
@@ -74,6 +74,18 @@ node c4-send.js "telegram" "<chat_id>" "[MEDIA:file]/path/to/document.pdf"
 - Config: `~/zylos/components/telegram/config.json`
 - Media: `~/zylos/components/telegram/media/`
 - Logs: `~/zylos/components/telegram/logs/`
+
+## Environment Variables
+
+Required in `~/zylos/.env`:
+
+```bash
+# Telegram Bot Token (required, from @BotFather)
+TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
+
+# Proxy URL (optional, needed behind firewalls e.g. China mainland)
+TELEGRAM_PROXY_URL=http://192.168.3.9:7890
+```
 
 ## Service Management
 

--- a/hooks/post-install.js
+++ b/hooks/post-install.js
@@ -12,7 +12,7 @@
  * - Create subdirectories (media, logs)
  * - Create default config.json
  * - Check for required environment variables
- * - Restart service with ecosystem.config.js (for custom PM2 options)
+ * - Restart service with ecosystem.config.cjs (for custom PM2 options)
  */
 
 import fs from 'fs';
@@ -88,7 +88,27 @@ if (fs.existsSync(ecosystemPath)) {
 
 console.log('\n[post-install] Complete!');
 
+console.log('\n========================================');
+console.log('  Telegram Bot Setup Checklist');
+console.log('========================================');
+console.log('');
+console.log('1. Create a bot via @BotFather on Telegram:');
+console.log('   - Send /newbot to @BotFather');
+console.log('   - Follow prompts to get your Bot Token');
+console.log('');
 if (!hasToken) {
-  console.log('\nNext: Add TELEGRAM_BOT_TOKEN and restart:');
-  console.log('  pm2 restart zylos-telegram');
+  console.log('2. Add Bot Token to ~/zylos/.env:');
+  console.log('   echo "TELEGRAM_BOT_TOKEN=your_token" >> ~/zylos/.env');
+} else {
+  console.log('2. Bot Token: already configured');
 }
+console.log('');
+console.log('3. (Optional) If behind a firewall/proxy, add to ~/zylos/.env:');
+console.log('   TELEGRAM_PROXY_URL=http://your-proxy:port');
+console.log('');
+console.log('4. Restart the bot:');
+console.log('   pm2 restart zylos-telegram');
+console.log('');
+console.log('5. Send a message to your bot on Telegram.');
+console.log('   First user to interact becomes the owner (admin).');
+console.log('========================================');

--- a/hooks/post-upgrade.js
+++ b/hooks/post-upgrade.js
@@ -29,26 +29,27 @@ if (fs.existsSync(configPath)) {
     let migrated = false;
     const migrations = [];
 
-    // Migration 1: Ensure features object and all fields
+    // Migration 1: Ensure features object and active fields
     if (!config.features) {
-      config.features = {};
+      config.features = { download_media: true };
       migrated = true;
       migrations.push('Added features object');
-    }
-    if (config.features.auto_split_messages === undefined) {
-      config.features.auto_split_messages = true;
-      migrated = true;
-      migrations.push('Added features.auto_split_messages');
-    }
-    if (config.features.max_message_length === undefined) {
-      config.features.max_message_length = 4000;
-      migrated = true;
-      migrations.push('Added features.max_message_length');
     }
     if (config.features.download_media === undefined) {
       config.features.download_media = true;
       migrated = true;
       migrations.push('Added features.download_media');
+    }
+    // Clean up dead config fields
+    if (config.features.auto_split_messages !== undefined) {
+      delete config.features.auto_split_messages;
+      migrated = true;
+      migrations.push('Removed dead features.auto_split_messages');
+    }
+    if (config.features.max_message_length !== undefined) {
+      delete config.features.max_message_length;
+      migrated = true;
+      migrations.push('Removed dead features.max_message_length');
     }
 
     // Migration 2: Add allowed_groups if missing
@@ -95,6 +96,17 @@ if (fs.existsSync(configPath)) {
       config.enabled = true;
       migrated = true;
       migrations.push('Added enabled field');
+    }
+
+    // Migration 7: Ensure message object with context_messages
+    if (!config.message) {
+      config.message = { context_messages: 10 };
+      migrated = true;
+      migrations.push('Added message.context_messages');
+    } else if (config.message.context_messages === undefined) {
+      config.message.context_messages = 10;
+      migrated = true;
+      migrations.push('Added message.context_messages');
     }
 
     // Save if migrated

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-telegram",
-  "version": "0.1.0-beta.15",
+  "version": "0.1.0-beta.16",
   "description": "Telegram Bot component for Zylos Agent",
   "type": "module",
   "main": "src/bot.js",

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -21,8 +21,6 @@ export const DEFAULT_CONFIG = {
   allowed_groups: [],
   smart_groups: [],
   features: {
-    auto_split_messages: true,
-    max_message_length: 4000,
     download_media: true
   },
   message: {

--- a/src/lib/context.js
+++ b/src/lib/context.js
@@ -59,7 +59,7 @@ export function getGroupContext(chatId) {
 
   const config = loadConfig();
   const MIN_CONTEXT = 5;
-  const MAX_CONTEXT = config.message?.context_messages || 10;
+  const MAX_CONTEXT = config.message?.context_messages ?? 10;
   const cursor = groupCursors[chatId] || null;
 
   const lines = fs.readFileSync(logFile, 'utf-8').trim().split('\n').filter(l => l);


### PR DESCRIPTION
## Summary
- Remove dead config fields (`features.auto_split_messages`, `features.max_message_length`) that are never read by runtime code
- Add 1-retry with 2s delay to `sendToC4` (was fire-and-forget, matching lark component fix)
- Fix `context.js` `||` to `??` so `context_messages: 0` is properly respected
- Full post-install setup checklist with BotFather link, proxy hint, and owner binding note
- Fix post-upgrade migrations: stop adding dead fields, add cleanup, add `message.context_messages`
- DESIGN.md: remove phantom "Product Key" reference and stale security log example
- SKILL.md: add Environment Variables section documenting `TELEGRAM_PROXY_URL`
- README.md: update stale version badge (beta.9 → beta.16)

## Test plan
- [ ] Verify bot starts correctly with updated config.js defaults
- [ ] Verify sendToC4 retry fires on simulated failure
- [ ] Run post-upgrade hook on existing config.json — dead fields should be removed
- [ ] Fresh install shows complete setup checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)