### PR TITLE
fix(group): empty allowed_groups now means open access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.18] - 2026-02-08
+
+### Fixed
+- Group permission: empty `allowed_groups` now means open access (all groups allowed), not closed access that blocks all non-owner @mentions
+
+---
+
 ## [0.1.0-beta.17] - 2026-02-08
 
 ### Changed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telegram
-version: 0.1.0-beta.17
+version: 0.1.0-beta.18
 description: Telegram Bot for user communication
 type: communication
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-telegram",
-  "version": "0.1.0-beta.17",
+  "version": "0.1.0-beta.18",
   "description": "Telegram Bot component for Zylos Agent",
   "type": "module",
   "main": "src/bot.js",

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -102,10 +102,12 @@ export function removeFromWhitelist(config, chatId) {
 
 /**
  * Check if group is in allowed_groups (can respond to @mentions)
+ * When allowed_groups is empty or not set, all groups are allowed (open mode).
+ * When allowed_groups has entries, only listed groups are allowed (restricted mode).
  */
 export function isAllowedGroup(config, chatId) {
   chatId = String(chatId);
-  if (!config.allowed_groups) return false;
+  if (!config.allowed_groups || config.allowed_groups.length === 0) return true;
   return config.allowed_groups.some(g => String(g.chat_id) === chatId);
 }
 


### PR DESCRIPTION
## Summary
- Fix `isAllowedGroup()` in `auth.js`: when `allowed_groups` is empty or not set, return `true` (open mode) instead of `false` (closed mode)
- This aligns with the same fix applied to zylos-lark (PR #10)
- Affects group @mention handling, message logging, and photo/document handlers

## Test plan
- [ ] Send @mention in group with empty `allowed_groups` — should respond (was blocked before)
- [ ] Groups listed in `allowed_groups` still work correctly (restricted mode)
- [ ] Smart groups unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)