### PR TITLE
feat(group): lazy download for photo/document messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.19] - 2026-02-08
+
+### Added
+- Lazy download for group photo/document messages: log metadata (file_id, msg_id) for context instead of downloading immediately in non-smart groups
+- Photo/document messages now logged in group context (were previously invisible)
+
+### Changed
+- Smart groups: photos/documents still download immediately
+- Non-smart groups: photos/documents only logged with metadata, available via context on next @mention
+
+---
+
 ## [0.1.0-beta.18] - 2026-02-08
 
 ### Fixed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telegram
-version: 0.1.0-beta.18
+version: 0.1.0-beta.19
 description: Telegram Bot for user communication
 type: communication
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-telegram",
-  "version": "0.1.0-beta.18",
+  "version": "0.1.0-beta.19",
   "description": "Telegram Bot component for Zylos Agent",
   "type": "module",
   "main": "src/bot.js",

--- a/src/lib/context.js
+++ b/src/lib/context.js
@@ -29,13 +29,16 @@ function saveCursors() {
 
 /**
  * Log a message to the chat's log file
+ * @param {string} chatId
+ * @param {object} ctx - Telegraf context
+ * @param {string} [textOverride] - Override text (e.g., with file metadata for lazy download)
  */
-export function logMessage(chatId, ctx) {
+export function logMessage(chatId, ctx, textOverride = null) {
   chatId = String(chatId);
   const username = ctx.from.username || ctx.from.first_name || 'unknown';
   const userId = ctx.from.id;
   const messageId = ctx.message.message_id;
-  const text = ctx.message.text || ctx.message.caption || '';
+  const text = textOverride || ctx.message.text || ctx.message.caption || '';
 
   const logEntry = {
     timestamp: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- Photos and documents in non-smart groups now log metadata (file_id, file_name, msg_id) instead of downloading immediately
- Metadata appears naturally in group context when bot is @mentioned later
- Smart groups and private chats still download immediately (unchanged)
- `logMessage` in context.js now accepts optional `textOverride` parameter

## Context format
```
[photo, file_id: AgACAgIAAxk..., msg_id: 123]
[file: report.pdf, file_id: BQACAgIAAxk..., msg_id: 456]
```

## Behavior matrix
| Chat type | Before | After |
|-----------|--------|-------|
| Private chat | Download immediately | No change |
| Smart group | Download immediately | No change |
| Non-smart group | Download immediately (no context) | Log metadata only (visible in context) |

## Test plan
- [ ] Send photo in non-smart group — should log metadata, NOT download
- [ ] @mention bot after — context should include photo metadata
- [ ] Send photo in smart group — should still download immediately
- [ ] Send photo in private chat — should still download immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)