### PR TITLE
refactor(hooks): update for lifecycle refactor

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -13,6 +13,7 @@ lifecycle:
   data_dir: ~/zylos/components/telegram
   hooks:
     post-install: hooks/post-install.js
+    pre-upgrade: hooks/pre-upgrade.js
     post-upgrade: hooks/post-upgrade.js
   preserve:
     - config.json

--- a/hooks/post-install.js
+++ b/hooks/post-install.js
@@ -2,11 +2,9 @@
 /**
  * Post-install hook for zylos-telegram
  *
- * Called by zylos CLI after standard installation steps:
- * - git clone
- * - npm install
- * - create data_dir
- * - register PM2 service (uses ecosystem.config.cjs automatically)
+ * Called by Claude after CLI installation (zylos add --json).
+ * CLI handles: download, npm install, manifest, registration.
+ * Claude handles: config collection, this hook, service start.
  *
  * This hook handles telegram-specific setup:
  * - Create subdirectories (media, logs)
@@ -65,8 +63,7 @@ if (!hasToken) {
   console.log('    echo "TELEGRAM_BOT_TOKEN=your_token" >> ' + ENV_FILE);
 }
 
-// Note: PM2 service is configured by zylos CLI's registerService()
-// which automatically uses ecosystem.config.cjs when available.
+// Note: PM2 service is started by Claude after this hook completes.
 
 console.log('\n[post-install] Complete!');
 

--- a/hooks/post-upgrade.js
+++ b/hooks/post-upgrade.js
@@ -2,15 +2,14 @@
 /**
  * Post-upgrade hook for zylos-telegram
  *
- * Called by zylos CLI after standard upgrade steps:
- * - git pull
- * - npm install
+ * Called by Claude after CLI upgrade completes (zylos upgrade --json).
+ * CLI handles: stop service, backup, file sync, npm install, manifest.
  *
  * This hook handles telegram-specific migrations:
  * - Config schema migrations
  * - Data format updates
  *
- * Note: Service restart is handled by zylos CLI after this hook.
+ * Note: Service restart is handled by Claude after this hook.
  */
 
 import fs from 'fs';

--- a/hooks/pre-upgrade.js
+++ b/hooks/pre-upgrade.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * Pre-upgrade hook for zylos-telegram
+ *
+ * Called by Claude BEFORE CLI upgrade steps.
+ * If this hook fails (exit code 1), the upgrade is aborted.
+ *
+ * This hook handles:
+ * - Backup critical data before upgrade
+ * - Validate upgrade prerequisites
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const HOME = process.env.HOME;
+const DATA_DIR = path.join(HOME, 'zylos/components/telegram');
+const configPath = path.join(DATA_DIR, 'config.json');
+
+console.log('[pre-upgrade] Running telegram pre-upgrade checks...\n');
+
+// 1. Backup config before upgrade
+if (fs.existsSync(configPath)) {
+  const backupPath = configPath + '.backup';
+  fs.copyFileSync(configPath, backupPath);
+  console.log('Config backed up to:', backupPath);
+}
+
+// 2. Add any pre-upgrade validations here
+// Example: Check if required services are available
+// if (!checkDependency()) {
+//   console.error('Error: Required dependency not available');
+//   process.exit(1);
+// }
+
+console.log('\n[pre-upgrade] Checks passed, proceeding with upgrade.');


### PR DESCRIPTION
## Summary

- Updated hook comments to reflect new ownership: hooks are called by Claude, not CLI
- Added `pre-upgrade.js` hook for config backup before upgrades
- Declared pre-upgrade hook in SKILL.md

Part of the lifecycle refactor (see zylos-core PR).

## Test plan

- [ ] `node hooks/post-install.js` still runs correctly
- [ ] `node hooks/pre-upgrade.js` backs up config.json
- [ ] `node hooks/post-upgrade.js` runs config migrations
- [ ] SKILL.md declares all 3 hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)