### PR TITLE
chore: release v0.1.0-beta.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.21] - 2026-02-09
+
+### Changed
+- Version bump for upgrade flow testing
+
+---
+
 ## [0.1.0-beta.20] - 2026-02-09
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-telegram",
-  "version": "0.1.0-beta.20",
+  "version": "0.1.0-beta.21",
   "description": "Telegram Bot component for Zylos Agent",
   "type": "module",
   "main": "src/bot.js",


### PR DESCRIPTION
## Summary
- Version bump to v0.1.0-beta.21 for upgrade flow testing

## After merge
- Tag `v0.1.0-beta.21` and `npm publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)