### PR TITLE
feat: relay C4 rejection reason to users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-beta.22] - 2026-02-10
+
+### Added
+- **Rejection response**: When C4 rejects a message (health down/recovering), bot replies to the user with the rejection reason instead of silently failing
+- `sendToC4` now uses `--json` flag and parses structured responses from c4-receive
+- Structured rejections skip retry (health won't recover in 2s); only unexpected failures trigger retry
+
+---
+
 ## [0.1.0-beta.21] - 2026-02-09
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-telegram",
-  "version": "0.1.0-beta.21",
+  "version": "0.1.0-beta.22",
   "description": "Telegram Bot component for Zylos Agent",
   "type": "module",
   "main": "src/bot.js",


### PR DESCRIPTION
## Summary
- When c4-receive rejects a message (health down/recovering), the bot now replies to the user with the rejection reason instead of silently failing
- `sendToC4` rewritten: uses `--json` flag, parses structured JSON response from c4-receive stdout
- Structured rejections (HEALTH_DOWN, HEALTH_RECOVERING) skip retry — health won't recover in 2s; only unexpected failures (node crash) trigger retry
- All 8 call sites updated with `onReject` callback via `bot.telegram.sendMessage`

## Test plan
- [ ] Set health=down: `echo '{"health":"down"}' > ~/zylos/comm-bridge/claude-status.json`
- [ ] Send TG message → bot replies with friendly error
- [ ] Restore: `echo '{"health":"ok"}' > ~/zylos/comm-bridge/claude-status.json`
- [ ] Send TG message → message queued normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)