### PR TITLE
fix(send): use absolute path for dotenv to avoid CWD dependency

### DIFF
--- a/scripts/send.js
+++ b/scripts/send.js
@@ -9,7 +9,10 @@
 import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
-import 'dotenv/config';
+import dotenv from 'dotenv';
+
+// Load .env from ~/zylos/.env (not cwd which may be comm-bridge directory)
+dotenv.config({ path: path.join(process.env.HOME, 'zylos/.env') });
 
 const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
 const PROXY_URL = process.env.TELEGRAM_PROXY_URL;


### PR DESCRIPTION
## Problem

`scripts/send.js` used `import 'dotenv/config'` which loads `.env` from the current working directory (CWD). When `comm-bridge` calls this script, CWD is the comm-bridge directory instead of `~/zylos/`, causing `TELEGRAM_BOT_TOKEN` to not be found.

## Solution

Changed to use absolute path pattern matching `src/lib/config.js`:

```js
import dotenv from 'dotenv';
dotenv.config({ path: path.join(process.env.HOME, 'zylos/.env') });
```

This ensures the correct `.env` file is loaded regardless of where the script is called from.

## Testing

- Verified the pattern matches existing `src/lib/config.js` implementation
- No behavioral changes for normal operation, only fixes the CWD-dependent bug

Generated with [Claude Code](https://claude.com/claude-code)