### PR TITLE
docs: add v0.2 upgrade plan

### DIFF
--- a/docs/upgrade-plan-v0.2.md
+++ b/docs/upgrade-plan-v0.2.md
@@ -788,8 +788,9 @@ These OpenClaw patterns are explicitly out of scope to maintain simplicity:
 
 - **Config migration:** `post-upgrade.js` auto-migrates legacy `allowed_groups[]` and
   `smart_groups[]` to the `groups` map. Legacy arrays are removed after migration.
-- **Log file format:** No change to `logs/{chatId}.log` format. In-memory history is
-  an optimization layer; log files remain the source of truth for cold-start replay.
+- **Log file format:** Additive backward-compatible schema change: `thread_id` field
+  added to log entries. Existing entries without `thread_id` are treated as non-topic
+  messages during replay. Log files remain the source of truth for cold-start replay.
 - **C4 endpoint format:** Backward compatible. Plain `chatId` (no `|`) continues to
   work; `chatId|msg:xxx|req:yyy|thread:zzz` is an additive extension with
   order-insensitive parsing.


### PR DESCRIPTION
## Summary
- Detailed optimization plan for zylos-telegram v0.2, referencing zylos-lark v0.1.5 patterns and OpenClaw UX
- 10 proposed changes across 3 priority tiers (P0-P3), organized in 3 implementation phases
- Key improvements: in-memory chat history, typing indicators, structured XML message format, reply-to context, enhanced group policy model, user name caching, improved message chunking

## Changes
- New file: `docs/upgrade-plan-v0.2.md` (plan document only, no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)