### PR TITLE
docs: add Chinese transliteration (赛洛丝) to pronunciation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <h1 align="center">🐙 zylos-telegram</h1>
 
-> **Zylos** (/ˈzaɪ.lɒs/) — Give your AI a life
+> **Zylos** (/ˈzaɪ.lɒs/ 赛洛丝) — Give your AI a life
 
 <p align="center">
   Telegram messaging component for <a href="https://github.com/zylos-ai/zylos-core">Zylos</a> agents.


### PR DESCRIPTION
Add Chinese transliteration 赛洛丝 to the Zylos pronunciation note in README.