### PR TITLE
docs: remove 🐙 from H1 (logo provides branding)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="./assets/logo.png" alt="Zylos" height="120">
 </p>
 
-<h1 align="center">🐙 zylos-telegram</h1>
+<h1 align="center">zylos-telegram</h1>
 
 > **Zylos** (/ˈzaɪ.lɒs/ 赛洛丝) — Give your AI a life
 


### PR DESCRIPTION
Removes the 🐙 emoji from the H1 title. The purple zylos wordmark logo above the title provides adequate branding.