### PR TITLE
Align Telegram HTML handling with openclaw

### DIFF
--- a/scripts/send.js
+++ b/scripts/send.js
@@ -23,6 +23,7 @@ const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
 const PROXY_URL = process.env.TELEGRAM_PROXY_URL;
 const MAX_LENGTH = 4000;
 const INTERNAL_TOKEN = crypto.createHash('sha256').update(BOT_TOKEN || '').digest('hex');
+const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
 
 // Parse arguments
 const args = process.argv.slice(2);
@@ -175,6 +176,11 @@ function splitMessage(text, maxLength) {
   return chunks;
 }
 
+function isTelegramParseError(err) {
+  const description = err?.telegramResponse?.description || err?.message || '';
+  return PARSE_ERR_RE.test(description);
+}
+
 /**
  * Determine text mode and prepare chunks accordingly.
  * Returns { chunks, parseMode } where parseMode is 'HTML' or null.
@@ -240,8 +246,8 @@ async function sendText(text) {
         try {
           await apiRequestWithRetry('sendMessage', params);
         } catch (retryErr) {
-          // If still 400 and we have parse_mode, fallback to plain text
-          if (params.parse_mode && retryErr.telegramResponse?.error_code === 400) {
+          // If still parse-entity error and we have parse_mode, fallback to plain text
+          if (params.parse_mode && retryErr.telegramResponse?.error_code === 400 && isTelegramParseError(retryErr)) {
             console.warn('[telegram] HTML parse failed, falling back to plain text');
             delete params.parse_mode;
             params.text = stripHtmlTags(chunks[i]);
@@ -250,7 +256,7 @@ async function sendText(text) {
             throw retryErr;
           }
         }
-      } else if (params.parse_mode && errCode === 400) {
+      } else if (params.parse_mode && errCode === 400 && isTelegramParseError(err)) {
         // HTML parse error — fallback to plain text (single retry)
         console.warn('[telegram] HTML parse failed, falling back to plain text');
         delete params.parse_mode;

--- a/src/lib/html-split.js
+++ b/src/lib/html-split.js
@@ -109,6 +109,58 @@ function findSafeSplitPoint(html, position) {
 }
 
 /**
+ * Return the ending ';' index of a valid HTML entity starting at `start`,
+ * or -1 if no valid entity starts there.
+ */
+function findEntityEnd(html, start) {
+  if (html[start] !== '&') return -1;
+
+  let i = start + 1;
+  if (i >= html.length) return -1;
+
+  if (html[i] === '#') {
+    i++;
+    if (i >= html.length) return -1;
+
+    const isHex = html[i] === 'x' || html[i] === 'X';
+    if (isHex) {
+      i++;
+      const hexStart = i;
+      while (/[0-9A-Fa-f]/.test(html[i] || '')) i++;
+      if (i === hexStart) return -1;
+    } else {
+      const decStart = i;
+      while (/[0-9]/.test(html[i] || '')) i++;
+      if (i === decStart) return -1;
+    }
+  } else {
+    const nameStart = i;
+    while (/[A-Za-z0-9]/.test(html[i] || '')) i++;
+    if (i === nameStart) return -1;
+  }
+
+  return html[i] === ';' ? i : -1;
+}
+
+/**
+ * Avoid splitting in the middle of an HTML entity like "&amp;".
+ */
+function avoidEntityMidSplit(html, from, to) {
+  const segment = html.substring(from, to);
+  const lastAmp = segment.lastIndexOf('&');
+  if (lastAmp === -1) return to;
+
+  const lastSemi = segment.lastIndexOf(';');
+  if (lastAmp < lastSemi) return to;
+
+  const ampIndex = from + lastAmp;
+  const entityEnd = findEntityEnd(html, ampIndex);
+  if (entityEnd === -1 || entityEnd < to) return to;
+
+  return ampIndex;
+}
+
+/**
  * Split HTML message into chunks, preserving tag integrity.
  *
  * Strategy:
@@ -176,6 +228,9 @@ export function splitHtmlMessage(html, maxLength = DEFAULT_MAX_LENGTH) {
         if (html[i] === '<') { breakAt = i; break; }
       }
     }
+
+    // Avoid cutting right through "&...;" entities.
+    breakAt = avoidEntityMidSplit(html, pos, breakAt);
 
     // Safety: must make progress
     if (breakAt <= pos) breakAt = pos + Math.max(1, Math.floor(available));

--- a/src/lib/markdown-html.js
+++ b/src/lib/markdown-html.js
@@ -20,6 +20,10 @@ function escapeHtml(text) {
     .replace(/>/g, '&gt;');
 }
 
+function escapeHtmlAttr(text) {
+  return escapeHtml(text).replace(/"/g, '&quot;');
+}
+
 /**
  * Strip HTML tags from text (for fallback to plain text).
  *
@@ -265,7 +269,7 @@ export function markdownToHtml(text) {
   // Step 9d: Restore markdown links as <a> tags
   for (let i = mdLinks.length - 1; i >= 0; i--) {
     const { text, url } = mdLinks[i];
-    const safeHref = url.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+    const safeHref = escapeHtmlAttr(url);
     const safeText = escapeHtml(text);
     result = result.replace(mdLinkToken(i), `<a href="${safeHref}">${safeText}</a>`);
   }
@@ -273,7 +277,7 @@ export function markdownToHtml(text) {
   // Step 9e: Restore bare URLs as <a> tags
   for (let i = bareLinks.length - 1; i >= 0; i--) {
     const url = bareLinks[i];
-    const safeHref = url.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+    const safeHref = escapeHtmlAttr(url);
     const safeText = escapeHtml(url);
     result = result.replace(bareLinkToken(i), `<a href="${safeHref}">${safeText}</a>`);
   }

--- a/test/html-split.test.js
+++ b/test/html-split.test.js
@@ -104,4 +104,13 @@ describe('splitHtmlMessage', () => {
       expect(chunk.length).toBeLessThan(250); // 200 + generous tag overhead
     }
   });
+
+  it('does not split in the middle of HTML entities', () => {
+    const msg = `<b>${'A'.repeat(30)} &amp; ${'B'.repeat(30)}</b>`;
+    const chunks = splitHtmlMessage(msg, 40);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk).not.toMatch(/&[a-zA-Z0-9#]*$/);
+    }
+  });
 });

--- a/test/markdown-html.test.js
+++ b/test/markdown-html.test.js
@@ -77,6 +77,11 @@ describe('markdownToHtml', () => {
       expect(result).not.toContain('href="https://a.com?q="');
     });
 
+    it('escapes angle brackets in href attribute', () => {
+      const result = markdownToHtml('click [here](https://a.com?q=<x>)');
+      expect(result).toBe('click <a href="https://a.com?q=&lt;x&gt;">here</a>');
+    });
+
     it('rejects non-http protocols', () => {
       expect(markdownToHtml('click [here](javascript:alert(1))'))
         .toBe('click [here](javascript:alert(1))');


### PR DESCRIPTION
## Summary
Align Telegram HTML handling with OpenClaw’s proven implementation in three areas:

1. Use full HTML attribute escaping for anchor `href` (`& < > "`).
2. Prevent HTML chunk splitting from cutting through entities like `&amp;` / `&#123;`.
3. Restrict plain-text fallback to Telegram parse-entity 400 errors only.

## Changes
- `src/lib/markdown-html.js`
  - Added `escapeHtmlAttr()` and switched link href escaping to it.
- `src/lib/html-split.js`
  - Added entity boundary detection and split protection.
- `scripts/send.js`
  - Added parse-error matcher and narrowed fallback behavior.
- `test/markdown-html.test.js`
  - Added href angle-bracket escaping regression test.
- `test/html-split.test.js`
  - Added entity split regression test.

## Risk / Impact Assessment
Expected impact is **low**, with targeted behavior changes:

- Link rendering:
  - `href` now escapes `<` and `>` in addition to existing `&` and `"`.
  - This is stricter/safe HTML and should not break valid URLs.
- Message splitting:
  - Splits may move slightly earlier when near an HTML entity boundary.
  - This avoids malformed entities and parse failures; content semantics unchanged.
- Fallback policy:
  - Non-parse 400 errors no longer auto-fallback to plain text.
  - This prevents masking genuine request errors (safer failure behavior).

Unaffected areas:
- Bot routing, auth, webhook/polling logic, media sending flow, and config parsing are unchanged.

## Verification
- `npm test` (vitest): **95 passed, 0 failed**.
