### PR TITLE
fix: prevent intraword underscores from triggering italic formatting

### DIFF
--- a/src/lib/markdown-html.js
+++ b/src/lib/markdown-html.js
@@ -57,8 +57,8 @@ export function hasMarkdownContent(text) {
 
   // Italic (*...*) — single asterisk not preceded/followed by space
   if (/(?<!\*)\*(?!\s)[^*]+(?<!\s)\*(?!\*)/.test(text)) return true;
-  // Italic (_..._) — single underscore
-  if (/(?<!_)_(?!\s)[^_]+(?<!\s)_(?!_)/.test(text)) return true;
+  // Italic (_..._) — single underscore, not intraword (e.g. snake_case)
+  if (/(?<![\w_])_(?!\s)[^_]+(?<!\s)_(?![\w_])/.test(text)) return true;
 
   // Links [text](url)
   if (/\[[^\]]+\]\([^)]+\)/.test(text)) return true;
@@ -238,8 +238,10 @@ export function markdownToHtml(text) {
   result = result.replace(/__(.+?)__/g, '<b>$1</b>');
 
   // Italic: *text* or _text_ (single, not double)
+  // Underscore italic requires non-word chars around the delimiters to avoid
+  // matching intraword underscores like snake_case or created_at.
   result = result.replace(/(?<!\*)\*(?!\s)(.+?)(?<!\s)\*(?!\*)/g, '<i>$1</i>');
-  result = result.replace(/(?<!_)_(?!\s)(.+?)(?<!\s)_(?!_)/g, '<i>$1</i>');
+  result = result.replace(/(?<![\w_])_(?!\s)(.+?)(?<!\s)_(?![\w_])/g, '<i>$1</i>');
 
   // Strikethrough: ~~text~~
   result = result.replace(/~~(.+?)~~/g, '<s>$1</s>');

--- a/test/markdown-html.test.js
+++ b/test/markdown-html.test.js
@@ -20,6 +20,30 @@ describe('markdownToHtml', () => {
     it('converts _text_ to <i>', () => {
       expect(markdownToHtml('hello _world_')).toBe('hello <i>world</i>');
     });
+
+    it('does not convert intraword underscores to italic (snake_case)', () => {
+      expect(markdownToHtml('snake_case_name')).toBe('snake_case_name');
+    });
+
+    it('does not convert underscores in identifiers like created_at', () => {
+      expect(markdownToHtml('the created_at column')).toBe('the created_at column');
+    });
+
+    it('does not convert underscores in multi-segment identifiers', () => {
+      expect(markdownToHtml('a_b_c_d')).toBe('a_b_c_d');
+    });
+
+    it('preserves underscored identifiers in list items', () => {
+      expect(markdownToHtml('- created_at and updated_at')).toBe('• created_at and updated_at');
+    });
+
+    it('still converts _italic_ surrounded by non-word chars', () => {
+      expect(markdownToHtml('(_italic_)')).toBe('(<i>italic</i>)');
+    });
+
+    it('still converts _multi word italic_', () => {
+      expect(markdownToHtml('_multi word italic_')).toBe('<i>multi word italic</i>');
+    });
   });
 
   describe('inline code', () => {
@@ -409,5 +433,17 @@ describe('hasMarkdownContent', () => {
 
   it('returns false for empty string', () => {
     expect(hasMarkdownContent('')).toBe(false);
+  });
+
+  it('returns false for intraword underscores (snake_case)', () => {
+    expect(hasMarkdownContent('snake_case_name')).toBe(false);
+  });
+
+  it('returns false for identifiers like created_at', () => {
+    expect(hasMarkdownContent('the created_at column')).toBe(false);
+  });
+
+  it('detects _italic_ with non-word boundaries', () => {
+    expect(hasMarkdownContent('hello _world_')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Underscores inside identifiers like `created_at`, `snake_case_name`, or `user_id` were being interpreted as Markdown italic markers by the `markdownToHtml` converter, corrupting the rendered output (e.g. `snake_case_name` → `snake` + *case* + `name`)
- Updated the underscore italic regex in both `hasMarkdownContent()` and `markdownToHtml()` to require non-word-character boundaries (`[\w_]`) around the `_` delimiters, consistent with CommonMark/GFM intraword emphasis rules
- Legitimate italic formatting like `_italic_` at word boundaries still works correctly

## Test plan

- [x] All 95 existing tests pass unchanged
- [x] Added 9 new test cases covering:
  - `snake_case_name` preserved as plain text
  - `created_at` identifier preserved
  - Multi-segment identifiers (`a_b_c_d`) preserved
  - List items with underscored identifiers preserved
  - Legitimate `_italic_` with non-word boundaries still converts
  - `_multi word italic_` still converts
  - `hasMarkdownContent` correctly returns false for intraword underscores
- [x] 104 total tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)