### PR TITLE
chore: release v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] - 2026-04-12
+
+### Fixed
+- Fix intraword italic false positives (#58)
+  - Underscores inside words (e.g. `created_at`, `snake_case`) are no longer treated as italic markers
+  - Updated regex to use CommonMark intraword emphasis boundary rules
+  - Added 9 new test cases covering intraword scenarios
+
 ## [0.3.4] - 2026-04-07
 
 ### Changed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telegram
-version: 0.3.4
+version: 0.3.5
 description: >-
   Telegram Bot communication channel (long polling mode, works behind firewalls).
   Use when: (1) replying to Telegram messages (DM or group @mentions),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-telegram",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-telegram",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-telegram",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Telegram Bot component for Zylos Agent",
   "type": "module",
   "main": "src/bot.js",


### PR DESCRIPTION
## Changes in v0.3.5

- **Fix intraword italic false positives** (#58) — underscores inside words (e.g. `created_at`, `snake_case`) no longer treated as italic markers. CommonMark intraword emphasis boundary rules. 9 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)