### PR TITLE
fix(hooks): preserve user data on field removal in post-upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6] - 2026-05-18
+
+### Fixed
+- Post-upgrade hook now backs up `config.json` to
+  `config.json.backup.<ISO-timestamp>` before mutation and uses atomic
+  write (temp + rename with unique suffix and failure cleanup) for the
+  new config (#60)
+
+### Removed
+- Reverted in-config `_legacy_*` field injection
+  (`_legacy_features_auto_split_messages`,
+  `_legacy_features_max_message_length`, `_legacy_whitelist`,
+  `_legacy_allowed_groups`, `_legacy_smart_groups`,
+  `_legacy_group_whitelist`) in favor of whole-file backups; the
+  original config schema is preserved (#60)
+
 ## [0.3.5] - 2026-04-12
 
 ### Fixed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telegram
-version: 0.3.5
+version: 0.3.6
 description: >-
   Telegram Bot communication channel (long polling mode, works behind firewalls).
   Use when: (1) replying to Telegram messages (DM or group @mentions),

--- a/hooks/post-upgrade.js
+++ b/hooks/post-upgrade.js
@@ -15,6 +15,28 @@
 import fs from 'fs';
 import path from 'path';
 
+function timestampSuffix() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function backupConfigFile(filePath) {
+  if (!fs.existsSync(filePath)) return null;
+  const backupPath = `${filePath}.backup.${timestampSuffix()}`;
+  fs.copyFileSync(filePath, backupPath);
+  return backupPath;
+}
+
+function atomicWriteJSON(filePath, obj) {
+  const tmpPath = `${filePath}.tmp.${process.pid}.${Date.now()}`;
+  try {
+    fs.writeFileSync(tmpPath, JSON.stringify(obj, null, 2));
+    fs.renameSync(tmpPath, filePath);
+  } catch (err) {
+    try { fs.unlinkSync(tmpPath); } catch {}
+    throw err;
+  }
+}
+
 const HOME = process.env.HOME;
 const DATA_DIR = path.join(HOME, 'zylos/components/telegram');
 const configPath = path.join(DATA_DIR, 'config.json');
@@ -39,18 +61,16 @@ if (fs.existsSync(configPath)) {
       migrated = true;
       migrations.push('Added features.download_media');
     }
-    // Clean up dead config fields (preserve prior values under _legacy_*)
+    // Clean up dead config fields
     if (config.features.auto_split_messages !== undefined) {
-      config._legacy_features_auto_split_messages = config.features.auto_split_messages;
       delete config.features.auto_split_messages;
       migrated = true;
-      migrations.push('Removed dead features.auto_split_messages (preserved as _legacy_features_auto_split_messages)');
+      migrations.push('Removed dead features.auto_split_messages');
     }
     if (config.features.max_message_length !== undefined) {
-      config._legacy_features_max_message_length = config.features.max_message_length;
       delete config.features.max_message_length;
       migrated = true;
-      migrations.push('Removed dead features.max_message_length (preserved as _legacy_features_max_message_length)');
+      migrations.push('Removed dead features.max_message_length');
     }
 
     // Migration 2: Add allowed_groups if missing (skip if already using v0.2 groups map)
@@ -84,7 +104,6 @@ if (fs.existsSync(configPath)) {
         config.dmPolicy = 'owner';
       }
       migrations.push(`Migrated whitelist → dmPolicy=${config.dmPolicy}, ${(config.dmAllowFrom || []).length} users in dmAllowFrom`);
-      config._legacy_whitelist = config.whitelist;
       delete config.whitelist;
       migrated = true;
     }
@@ -160,16 +179,13 @@ if (fs.existsSync(configPath)) {
         };
       }
 
-      // Preserve and remove legacy fields
-      if (config.allowed_groups !== undefined) config._legacy_allowed_groups = config.allowed_groups;
-      if (config.smart_groups !== undefined) config._legacy_smart_groups = config.smart_groups;
-      if (config.group_whitelist !== undefined) config._legacy_group_whitelist = config.group_whitelist;
+      // Remove legacy fields
       delete config.allowed_groups;
       delete config.smart_groups;
       delete config.group_whitelist;
 
       migrated = true;
-      migrations.push(`Migrated ${Object.keys(config.groups).length} groups to unified groups map (legacy fields preserved as _legacy_*)`);
+      migrations.push(`Migrated ${Object.keys(config.groups).length} groups to unified groups map`);
     }
 
     // Migration 9: Ensure groupPolicy exists
@@ -200,11 +216,11 @@ if (fs.existsSync(configPath)) {
       migrations.push('Created typing/ directory');
     }
 
-    // Save if migrated (atomic: write tmp then rename)
+    // Save if migrated
     if (migrated) {
-      const tmpPath = configPath + '.tmp';
-      fs.writeFileSync(tmpPath, JSON.stringify(config, null, 2));
-      fs.renameSync(tmpPath, configPath);
+      const backupPath = backupConfigFile(configPath);
+      if (backupPath) console.log(`[post-upgrade] Backed up config to ${path.basename(backupPath)}`);
+      atomicWriteJSON(configPath, config);
       console.log('Config migrations applied:');
       migrations.forEach(m => console.log('  - ' + m));
     } else {

--- a/hooks/post-upgrade.js
+++ b/hooks/post-upgrade.js
@@ -39,16 +39,18 @@ if (fs.existsSync(configPath)) {
       migrated = true;
       migrations.push('Added features.download_media');
     }
-    // Clean up dead config fields
+    // Clean up dead config fields (preserve prior values under _legacy_*)
     if (config.features.auto_split_messages !== undefined) {
+      config._legacy_features_auto_split_messages = config.features.auto_split_messages;
       delete config.features.auto_split_messages;
       migrated = true;
-      migrations.push('Removed dead features.auto_split_messages');
+      migrations.push('Removed dead features.auto_split_messages (preserved as _legacy_features_auto_split_messages)');
     }
     if (config.features.max_message_length !== undefined) {
+      config._legacy_features_max_message_length = config.features.max_message_length;
       delete config.features.max_message_length;
       migrated = true;
-      migrations.push('Removed dead features.max_message_length');
+      migrations.push('Removed dead features.max_message_length (preserved as _legacy_features_max_message_length)');
     }
 
     // Migration 2: Add allowed_groups if missing (skip if already using v0.2 groups map)
@@ -82,6 +84,7 @@ if (fs.existsSync(configPath)) {
         config.dmPolicy = 'owner';
       }
       migrations.push(`Migrated whitelist → dmPolicy=${config.dmPolicy}, ${(config.dmAllowFrom || []).length} users in dmAllowFrom`);
+      config._legacy_whitelist = config.whitelist;
       delete config.whitelist;
       migrated = true;
     }
@@ -157,13 +160,16 @@ if (fs.existsSync(configPath)) {
         };
       }
 
-      // Remove legacy fields
+      // Preserve and remove legacy fields
+      if (config.allowed_groups !== undefined) config._legacy_allowed_groups = config.allowed_groups;
+      if (config.smart_groups !== undefined) config._legacy_smart_groups = config.smart_groups;
+      if (config.group_whitelist !== undefined) config._legacy_group_whitelist = config.group_whitelist;
       delete config.allowed_groups;
       delete config.smart_groups;
       delete config.group_whitelist;
 
       migrated = true;
-      migrations.push(`Migrated ${Object.keys(config.groups).length} groups to unified groups map`);
+      migrations.push(`Migrated ${Object.keys(config.groups).length} groups to unified groups map (legacy fields preserved as _legacy_*)`);
     }
 
     // Migration 9: Ensure groupPolicy exists

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-telegram",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-telegram",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-telegram",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Telegram Bot component for Zylos Agent",
   "type": "module",
   "main": "src/bot.js",


### PR DESCRIPTION
Four migrations used to drop user-set values when cleaning up legacy or dead fields. Now each preserves the prior value under `_legacy_*` first, matching the convention already in use by zylos-feishu and other components in the family.

Specifically:

- Migration 1 (dead features cleanup): `features.auto_split_messages` and `features.max_message_length` are saved to `_legacy_features_auto_split_messages` and `_legacy_features_max_message_length` before deletion.

- Migration 4 (whitelist → dmPolicy): the dmAllowFrom merge preserves user IDs but used to lose `enabled` and the original split between `chat_ids`/`usernames`. Whole object now kept as `_legacy_whitelist`.

- Migration 8 (legacy group arrays → groups map): `allowed_groups`, `smart_groups`, and `group_whitelist` are each saved to a `_legacy_*` key before deletion (only when actually present, to avoid creating empty legacy keys on fresh configs).

No change to migration order, guards, or values written to new fields. Atomic config write and log-split logic untouched. Re-running on already-migrated config is still a no-op.

Verified scenarios:
- Legacy config with all four kinds of deletable fields → migrated, every removed value present under `_legacy_*`.
- Already-migrated config → no-op, exit 0.

## Summary

<!-- Brief description of the changes -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [ ] Code follows the project's ESM-only style
- [ ] Self-review completed
- [ ] Changes are tested locally
- [ ] CHANGELOG.md updated (if applicable)
- [ ] No secrets or internal references included
