### PR TITLE
docs: fix admin help owner bypass wording

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -125,7 +125,7 @@ pm2 restart zylos-telegram   # Restart service
 ## Owner
 
 First user to interact with the bot becomes the owner (admin).
-Owner bypasses allowlist checks only (DM allowlist and per-group allowFrom).
+Owner bypasses allowlist checks only: DM allowlist, group allowlist/configured-groups checks, and per-group `allowFrom`.
 `groupPolicy: disabled` blocks all group messages, including from the owner.
 
 ## Access Control

--- a/SKILL.md
+++ b/SKILL.md
@@ -125,7 +125,8 @@ pm2 restart zylos-telegram   # Restart service
 ## Owner
 
 First user to interact with the bot becomes the owner (admin).
-Owner always bypasses all access checks (DM and group) regardless of policy settings.
+Owner bypasses allowlist checks only (DM allowlist and per-group allowFrom).
+`groupPolicy: disabled` blocks all group messages, including from the owner.
 
 ## Access Control
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -125,7 +125,11 @@ pm2 restart zylos-telegram   # Restart service
 ## Owner
 
 First user to interact with the bot becomes the owner (admin).
-Owner bypasses allowlist checks only: DM allowlist, group allowlist/configured-groups checks, and per-group `allowFrom`.
+Owner bypasses allowlist checks only: the DM allowlist and per-group `allowFrom`.
+For **text** messages, an owner `@mention` also bypasses the group allowlist /
+configured-groups check (the bot responds even in an unconfigured group).
+**Media and voice** (photo / document / voice) still require the group to be
+configured or smart-enabled, even for the owner.
 `groupPolicy: disabled` blocks all group messages, including from the owner.
 
 ## Access Control

--- a/src/admin.js
+++ b/src/admin.js
@@ -339,8 +339,9 @@ Commands:
 Permission flow:
   Private DM:  dmPolicy (open|allowlist|owner) + dmAllowFrom
   Group chat:  groupPolicy → groups config → per-group allowFrom
-  Owner bypasses allowlist checks only. groupPolicy: disabled blocks
-  all group messages, including from owner.
+  Owner bypasses allowlist checks only: DM allowlist, group
+  allowlist/configured-groups, and per-group allowFrom.
+  groupPolicy: disabled blocks all group messages, including from owner.
 
 After changes, restart bot: pm2 restart zylos-telegram
 `);

--- a/src/admin.js
+++ b/src/admin.js
@@ -339,7 +339,8 @@ Commands:
 Permission flow:
   Private DM:  dmPolicy (open|allowlist|owner) + dmAllowFrom
   Group chat:  groupPolicy → groups config → per-group allowFrom
-  Owner always bypasses all checks.
+  Owner bypasses allowlist checks only. groupPolicy: disabled blocks
+  all group messages, including from owner.
 
 After changes, restart bot: pm2 restart zylos-telegram
 `);

--- a/src/admin.js
+++ b/src/admin.js
@@ -339,8 +339,9 @@ Commands:
 Permission flow:
   Private DM:  dmPolicy (open|allowlist|owner) + dmAllowFrom
   Group chat:  groupPolicy → groups config → per-group allowFrom
-  Owner bypasses allowlist checks only: DM allowlist, group
-  allowlist/configured-groups, and per-group allowFrom.
+  Owner bypasses the DM allowlist and per-group allowFrom. For text,
+  an owner @mention also bypasses the group allowlist/configured-groups
+  check; media/voice still require a configured or smart-enabled group.
   groupPolicy: disabled blocks all group messages, including from owner.
 
 After changes, restart bot: pm2 restart zylos-telegram


### PR DESCRIPTION
## Summary
- Admin CLI help text said "Owner always bypasses all checks" — too broad and incorrect
- SKILL.md had the same overly broad wording
- Code correctly blocks owner when `groupPolicy: disabled` (verified in `src/lib/auth.js`)
- Updated both to: "Owner bypasses allowlist checks only. groupPolicy: disabled blocks all group messages, including from owner."

## Test plan
- [x] 104/104 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)