### PR TITLE
feat(group-access): owner invite auto-configures owner-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **BREAKING (group access)**: Bot joining a group now branches on the
+  inviter:
+  - **Owner invited** → the group is auto-configured, but locked to
+    `allowFrom: [<ownerId>]` (owner-only — *not* the admin-CLI default
+    `['*']`). The bot stays silent in the group on join; no in-group
+    notice is posted. This gives the group a logged context immediately
+    (so subsequent messages — including from members the owner has not
+    yet authorized — are recorded in `logs/<chatId>.log`) while keeping
+    bot access locked down until the owner adds more senders via
+    `admin.js set-group-allowfrom`.
+  - **Non-owner invited** → the group is **not** added. The bot stays
+    silent in the group; the owner is DM'd the exact `admin.js add-group`
+    command to authorize manually if desired.
+
+  Previous behavior added every owner-invited group with
+  `allowFrom: ['*']` (opening bot access to everyone in the group on
+  arrival). The new flow keeps the same owner-as-inviter convenience but
+  defaults to owner-only access, matching the principle of least privilege.
+
+  Re-joining an already-configured group remains a no-op (existing
+  allowlist entry is preserved).
+
+- `addGroup(config, chatId, name, mode, opts)` in `src/lib/auth.js` gained
+  an optional `opts.allowFrom` parameter (array of user-id strings) to
+  override the default `['*']` initial allowlist. The admin CLI path
+  (`admin.js add-group`) is unchanged and still opts into `['*']`.
+
 ## [0.3.6] - 2026-05-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-02
+
 ### Changed
 - **BREAKING (group access)**: Bot joining a group now branches on the
   inviter:

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telegram
-version: 0.3.6
+version: 0.4.0
 description: >-
   Telegram Bot communication channel (long polling mode, works behind firewalls).
   Use when: (1) replying to Telegram messages (DM or group @mentions),

--- a/SKILL.md
+++ b/SKILL.md
@@ -137,6 +137,26 @@ DM and group access are controlled by independent policies:
 
 Per-group options: `mode` (mention/smart), `allowFrom` (restrict senders), `historyLimit`.
 
+### Group join behavior (on bot invite)
+
+The bot branches on who invited it:
+
+- **Owner invited** → group is auto-configured with `allowFrom: [<ownerId>]`
+  (owner-only — *not* the admin-CLI default `['*']`). The bot stays silent
+  in the group on join; no in-group notice is posted. This gives the
+  group a logged context immediately (so subsequent messages — including
+  from members the owner has not yet authorized — are recorded in
+  `logs/<chatId>.log` for later id resolution) while keeping access
+  locked down until the owner explicitly authorizes more senders via
+  `admin.js set-group-allowfrom`.
+
+- **Non-owner invited** → group is **not** added. The bot stays silent in
+  the group; the owner is DM'd the exact `admin.js add-group` command to
+  authorize manually if desired.
+
+Re-joining an already-configured group is a no-op (the existing
+`config.groups[chatId]` entry stays valid).
+
 ## Admin CLI
 
 Manage bot configuration via `admin.js`:
@@ -169,6 +189,69 @@ $ADM set-group-history-limit <chat_id> <n>    # Set per-group context message li
 ```
 
 After changes, restart: `pm2 restart zylos-telegram`
+
+## Resolving @username to user_id from message logs
+
+Telegram Bot API has no direct `@username → user_id` resolver for regular
+users, and `config.groups.<chatId>.allowFrom` requires **numeric** user_ids
+to match (the auth check is a strict `array.includes(senderId)`). Storing
+`@username` literally in `allowFrom` will silently fail to match.
+
+But the bot already logs every processed message per group as one JSON line
+per row, with `user_id` (numeric) and `user_name` (the @username at the
+time of the message) included. Because owner-invited groups land
+**configured** (with `allowFrom: [<ownerId>]`), the text handler logs
+every incoming message *before* the per-sender `allowFrom` rejection
+fires — so a non-allowed member's `user_id` ends up in
+`logs/<chatId>.log` the first time they @-mention the bot, even though
+the bot replies with the no-permission notice. So when the owner says
+*"allow @felix to access you in this group"*, the workflow is:
+
+1. Pick the right log file by chat:
+
+   ```
+   ~/zylos/components/telegram/logs/<chatId>.log
+   ```
+
+   (Owner usually says this *inside* the group; `<chatId>` is the current
+   chat. For DM allowlist, scan **all** log files.)
+
+2. Grep for the target user_name:
+
+   ```bash
+   grep -E '"user_name":"felixl0707"' \
+     ~/zylos/components/telegram/logs/-5298485474.log | head -1
+   ```
+
+   Extract `user_id` from the JSON (e.g., `8614077771`). The log captures
+   the id even when the message didn't @-mention this bot — any message
+   in an authorized group is logged.
+
+3. Apply the change via admin.js, **including the owner's own id** so they
+   don't lock themselves out:
+
+   ```bash
+   node ~/zylos/.claude/skills/telegram/src/admin.js \
+     set-group-allowfrom <chatId> <target-id> <owner-id>
+   ```
+
+   `config.json` hot-reloads — no `pm2 restart` needed.
+
+4. Confirm to the owner:
+   - Which numeric id was resolved
+   - The new `allowFrom` value
+   - That all other group members are now blocked
+
+If the target user has never sent any message in any of the bot's logged
+chats, no log entry exists yet. In that case:
+- Ask them to @-mention the bot once **in an owner-configured group**
+  (any group the owner invited the bot into — those land configured
+  owner-only, so non-allowed members can be logged on first interaction
+  even though the bot rejects them at the per-sender check), OR
+- Get the numeric chat_id from the owner directly.
+
+`logs/<chatId>.log` is also the source of truth for in-group message
+history; this section only describes how to use it for ID resolution.
 
 ## Group Context
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-telegram",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-telegram",
-      "version": "0.3.6",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-telegram",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "description": "Telegram Bot component for Zylos Agent",
   "type": "module",
   "main": "src/bot.js",

--- a/src/bot.js
+++ b/src/bot.js
@@ -393,8 +393,23 @@ function notifyOwnerPendingGroup(chatId, chatTitle, addedBy) {
 
 /**
  * Handle bot being added to a group.
- * Uses my_chat_member exclusively — this is the reliable event for bot status changes.
- * new_chat_members is NOT used for bot-self-add to avoid duplicate messages (#43).
+ *
+ * Branches on whether the inviter is the bot owner:
+ *
+ *   Owner invited → auto-configure the group, but lock it to owner-only
+ *     (`allowFrom: [ownerId]`, NOT the admin-CLI default `['*']`). The bot
+ *     stays silent in the group on join; no in-group notice is posted.
+ *     This gives the group a logged context immediately while keeping
+ *     access restricted until the owner authorizes additional users via
+ *     `admin.js set-group-allowfrom`.
+ *
+ *   Non-owner invited → do NOT add the group. Bot stays silent in the
+ *     group; owner is DM'd the exact `admin.js add-group` command to
+ *     authorize manually if desired.
+ *
+ * Uses my_chat_member exclusively — this is the reliable event for bot
+ * status changes. new_chat_members is NOT used for bot-self-add to avoid
+ * duplicate messages (#43).
  */
 bot.on('my_chat_member', (ctx) => {
   const update = ctx.myChatMember;
@@ -413,18 +428,28 @@ bot.on('my_chat_member', (ctx) => {
   const chatId = chat.id;
   const chatTitle = chat.title || 'Unknown Group';
   const addedById = String(update.from.id);
+  const addedByDisplay = update.from.username || update.from.first_name || addedById;
 
-  if (String(config.owner?.chat_id) === addedById) {
-    const added = addGroup(config, chatId, chatTitle, 'mention');
-    if (added) {
-      bot.telegram.sendMessage(chatId, `Group added. Members can now @${bot.botInfo?.username} to chat.`).catch(() => {});
-    } else {
-      bot.telegram.sendMessage(chatId, 'Group is already configured.').catch(() => {});
-    }
-  } else {
-    bot.telegram.sendMessage(chatId, 'Bot joined, but requires admin approval to respond.').catch(() => {});
-    notifyOwnerPendingGroup(chatId, chatTitle, update.from.username || update.from.first_name || addedById);
+  // If the group is already configured, no action needed (bot was kicked
+  // and re-added — the existing allowlist entry is still valid).
+  if (config.groups?.[chatId]) {
+    console.log(`[telegram] Re-joined existing group ${chatId} (${chatTitle}) — no action`);
+    return;
   }
+
+  const ownerId = config.owner?.chat_id ? String(config.owner.chat_id) : null;
+  const invitedByOwner = ownerId && addedById === ownerId;
+
+  if (invitedByOwner) {
+    // Owner-invited: auto-configure, but locked to owner only.
+    addGroup(config, chatId, chatTitle, 'mention', { allowFrom: [ownerId] });
+    console.log(`[telegram] Owner-invited group ${chatId} (${chatTitle}) — configured owner-only`);
+    return;
+  }
+
+  // Non-owner invited: do not authorize; stay silent in the group.
+  console.log(`[telegram] Non-owner-invited group ${chatId} (${chatTitle}) by ${addedByDisplay} — not added`);
+  notifyOwnerPendingGroup(chatId, chatTitle, addedByDisplay);
 });
 
 /**

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -178,17 +178,24 @@ export function getGroupName(config, chatId, chatTitle) {
  * @param {string|number} chatId
  * @param {string} name
  * @param {'mention'|'smart'} [mode='mention']
+ * @param {{allowFrom?: string[]}} [opts] - optional initial allowFrom override
+ *   (e.g. `['<owner-user-id>']` for owner-invited groups). Defaults to `['*']`
+ *   for back-compat with the admin CLI flow.
  * @returns {boolean} true if added, false if already exists
  */
-export function addGroup(config, chatId, name, mode = 'mention') {
+export function addGroup(config, chatId, name, mode = 'mention', opts = {}) {
   chatId = String(chatId);
   if (!config.groups) config.groups = {};
   if (config.groups[chatId]) return false;
 
+  const allowFrom = Array.isArray(opts.allowFrom) && opts.allowFrom.length > 0
+    ? opts.allowFrom.map(String)
+    : ['*'];
+
   config.groups[chatId] = {
     name,
     mode,
-    allowFrom: ['*'],
+    allowFrom,
     historyLimit: config.message?.context_messages || 5,
     added_at: new Date().toISOString()
   };


### PR DESCRIPTION
## Summary

Refines the bot's group-join behavior (`my_chat_member`) to branch on whether the inviter is the bot owner, so the group is captured into `config.groups{}` immediately but bot access stays locked down until the owner explicitly authorizes more senders.

## Why

The previous `my_chat_member` handler auto-called `addGroup(config, chatId, chatTitle, 'mention')` whenever the owner invited the bot, which seeded the group with `allowFrom: ['*']`. That implicitly granted every member of that group permission to talk to the bot the moment the owner hit "Add to chat" — surprising and unsafe when groups contain people the owner doesn't intend to give bot access to.

This PR makes the inviter dispatch explicit and applies least privilege.

## New behavior

| Inviter | What happens | `config.groups[chatId]` |
|---|---|---|
| **Owner** | Group is auto-configured with `mode: 'mention'`, `allowFrom: [<ownerId>]`. Bot stays silent in the group on join — no in-group notice posted. | Created, owner-only |
| **Non-owner** | Group is **not** added. Bot stays silent in the group. Owner is DM'd the exact `admin.js add-group` command. | Not created |
| Re-join an already-configured group | No-op (existing entry preserved). | Untouched |

Because owner-invited groups land in `config.groups{}`, the `text` handler's `if (isAllowed) logAndRecord(...)` path fires for **every** subsequent message — including from members the owner has not yet authorized. Those messages still get rejected at the per-sender `allowFrom` check, but the `user_id` is recorded in `logs/<chatId>.log` for later `@username → user_id` resolution.

## Changes

- `src/lib/auth.js` — `addGroup(config, chatId, name, mode, opts)` gains an optional `opts.allowFrom` parameter (array of user-id strings) to override the default `['*']`. The admin CLI path (`admin.js add-group`) is unchanged and still opts into `['*']`.
- `src/bot.js` — `my_chat_member` handler branches on `inviter == owner`. Owner-invited path calls `addGroup` with `allowFrom: [ownerId]` and stays silent. Non-owner path posts no in-group notice; only DMs owner.
- `SKILL.md` — new "Group join behavior (on bot invite)" subsection under Access Control; new "Resolving @username to user_id from message logs" section documenting the authorize-by-grep workflow.
- `CHANGELOG.md` — `[0.4.0]` entry describing the two-branch flow and the `addGroup` signature extension.
- Version bump 0.3.6 → **0.4.0** (BREAKING behavior change): `package.json`, `package-lock.json`, `SKILL.md` frontmatter, `CHANGELOG.md` per the release-process discipline in CLAUDE.md.

## Upgrade compatibility

- **Data**: zero schema change. `config.groups.<chatId>.allowFrom` was already a `string[]`; this PR just seeds it with `[ownerId]` instead of `['*']` for owner-invited groups.
- **Existing configured groups**: untouched. The `my_chat_member` handler early-returns on already-configured groups; old `allowFrom: ['*']` entries keep working as-is.
- **`hooks/post-upgrade.js`**: no new migration entry needed.
- **Future behavior**: owner-invite no longer opens bot access to everyone in the group on arrival. If that previous behavior is desired for a specific group, the owner can run `admin.js set-group-allowfrom <chatId> "*"` after the auto-add.

## Verification

- `node --check src/bot.js`
- `node --check src/lib/auth.js`
- `npm test` — passes (no test additions; `my_chat_member` paths are exercised in development; smoke test in real groups is the canonical check)

## Smoke test plan

- [ ] Owner adds bot to a new group → group lands in `config.groups{}` with `allowFrom: [ownerId]`; no in-group notice; no DM to owner.
- [ ] Owner @-mentions the bot in that group → bot replies; message logged.
- [ ] Non-owner @-mentions the bot in that group → bot replies "no permission"; message **still logged** with `user_id` in `logs/<chatId>.log`.
- [ ] Owner runs `admin.js set-group-allowfrom <chatId> <ownerId> <newUserId>` → non-owner can now interact.
- [ ] Non-owner adds bot to a new group → group is not added; no in-group notice; owner gets DM with the `admin.js add-group` command.
- [ ] Bot kicked + re-added to an already-configured group → no-op; existing `allowFrom` preserved.