### PR TITLE
feat(members-cache): passive @username → user_id cache for admin commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Members cache** (`~/zylos/components/telegram/members.json`): passive
+  `@username → user_id` mapping populated from observed messages (text /
+  photo / document / voice / `/start`). Telegram Bot API has no direct
+  username → id resolver for regular users, so the cache fills the gap so
+  admin.js commands can accept `@username` arguments for users the bot
+  has previously seen.
+- `admin.js list-members` — list all cached `@username → user_id` entries.
+- `admin.js resolve <@username>` — look up a single username.
+- `admin.js add-dm-allow @username` and
+  `admin.js set-group-allowfrom <chat_id> @user1 @user2 ...` now resolve
+  `@username` arguments via the cache before storing. Numeric ids and `*`
+  pass through unchanged. Unknown @usernames are stored as literals with
+  a warning — the group filter requires numeric ids, so the command can
+  be re-run once the user is seen to resolve them.
+- post-upgrade hook creates an empty `members.json` and prints a one-time
+  notice describing the new commands.
+
+### Changed
+- The members cache stores ids (which are stable), so `allowFrom` lists
+  written by `set-group-allowfrom @user` are immune to subsequent
+  username changes — `@user` may change to `@user2` later, but the stored
+  numeric id still identifies the same person.
+
 ## [0.3.6] - 2026-05-18
 
 ### Fixed

--- a/hooks/post-upgrade.js
+++ b/hooks/post-upgrade.js
@@ -216,6 +216,15 @@ if (fs.existsSync(configPath)) {
       migrations.push('Created typing/ directory');
     }
 
+    // Migration 13: Initialize empty members cache file
+    // (lazy-created on first write too, but creating it here makes the
+    //  existence explicit for first-run admin commands).
+    const membersPath = path.join(DATA_DIR, 'members.json');
+    if (!fs.existsSync(membersPath)) {
+      fs.writeFileSync(membersPath, '{}\n');
+      migrations.push('Created empty members.json (username → user_id cache)');
+    }
+
     // Save if migrated
     if (migrated) {
       const backupPath = backupConfigFile(configPath);
@@ -288,5 +297,26 @@ if (fs.existsSync(logsDir)) {
     console.warn(`[post-upgrade] Log split failed (non-fatal): ${err.message}`);
   }
 }
+
+// First-run notice for the members cache feature (only when the cache
+// file is empty — i.e. upgrade from a pre-cache version).
+const membersFile = path.join(DATA_DIR, 'members.json');
+try {
+  const raw = fs.existsSync(membersFile) ? fs.readFileSync(membersFile, 'utf8').trim() : '';
+  if (!raw || raw === '{}') {
+    console.log(`
+[post-upgrade] New: members cache (username → user_id)
+  The bot now passively records observed @username → user_id mappings as
+  messages flow through, so admin.js commands can accept @username args
+  for previously-seen users. Lookup:
+      node admin.js list-members
+      node admin.js resolve @someone
+  Used implicitly by:
+      node admin.js set-group-allowfrom <chatId> @user1 @user2 ...
+      node admin.js add-dm-allow @user
+  Cache: ${membersFile}
+`);
+  }
+} catch {}
 
 console.log('\n[post-upgrade] Complete!');

--- a/src/admin.js
+++ b/src/admin.js
@@ -8,6 +8,23 @@
 
 import { loadConfig, saveConfig } from './lib/config.js';
 import { addGroup, removeGroup } from './lib/auth.js';
+import { resolveUsername, listMembers } from './lib/members.js';
+
+// Resolve `@username` to numeric user_id via the members cache.
+// Returns the original argument unchanged if it's already numeric (or starts
+// without `@`), or if the cache has no entry. The caller decides whether a
+// fallback is acceptable.
+function resolveUserArg(arg) {
+  const s = String(arg);
+  if (!s.startsWith('@')) return s;          // numeric id or bare username — pass through
+  const id = resolveUsername(s);
+  if (id) {
+    console.log(`  ${s} → ${id} (from members cache)`);
+    return id;
+  }
+  console.warn(`  WARN: ${s} not in members cache — storing literal. The bot has not seen this user yet; ask them to message the bot once, then re-run this command to resolve to a numeric id.`);
+  return s;
+}
 
 // Commands
 const commands = {
@@ -117,7 +134,8 @@ const commands = {
 
   'set-group-allowfrom': (chatId, ...userIds) => {
     if (!chatId || userIds.length === 0) {
-      console.error('Usage: admin.js set-group-allowfrom <chat_id> <user_ids...>');
+      console.error('Usage: admin.js set-group-allowfrom <chat_id> <user_ids_or_@usernames...>');
+      console.error('  Special value: * (allow all members)');
       process.exit(1);
     }
 
@@ -127,13 +145,18 @@ const commands = {
       process.exit(1);
     }
 
-    config.groups[String(chatId)].allowFrom = userIds.map(String);
+    // Resolve every @username via the members cache. `*` and numeric ids
+    // pass through unchanged. Unknown @usernames are stored literally with
+    // a warning — group filter requires numeric ids so unresolved entries
+    // won't match until the user is seen and the command is re-run.
+    const resolved = userIds.map(u => u === '*' ? '*' : resolveUserArg(u));
+
+    config.groups[String(chatId)].allowFrom = resolved.map(String);
     if (!saveConfig(config)) {
       console.error('[telegram] Failed to save config to disk');
       process.exit(1);
     }
     console.log(`Set allowFrom for ${chatId}: ${config.groups[String(chatId)].allowFrom.join(', ')}`);
-    console.log('Run: pm2 restart zylos-telegram');
   },
 
   'set-group-history-limit': (chatId, limit) => {
@@ -197,24 +220,27 @@ const commands = {
       console.error('Usage: admin.js add-dm-allow <chat_id_or_@username>');
       process.exit(1);
     }
+    // If `@username` and we've seen the user, prefer storing the numeric id
+    // (immune to subsequent username changes). Falls back to the literal
+    // @username, which isDmAllowed() also accepts as a string match.
+    const resolved = resolveUserArg(value);
     const config = loadConfig();
     if (!Array.isArray(config.dmAllowFrom)) {
       config.dmAllowFrom = [];
     }
-    if (!config.dmAllowFrom.includes(value)) {
-      config.dmAllowFrom.push(value);
+    if (!config.dmAllowFrom.includes(resolved)) {
+      config.dmAllowFrom.push(resolved);
       if (!saveConfig(config)) {
         console.error('[telegram] Failed to save config to disk');
         process.exit(1);
       }
-      console.log(`Added ${value} to dmAllowFrom`);
+      console.log(`Added ${resolved} to dmAllowFrom`);
     } else {
-      console.log(`${value} already in dmAllowFrom`);
+      console.log(`${resolved} already in dmAllowFrom`);
     }
     if ((config.dmPolicy || 'owner') !== 'allowlist') {
       console.log(`Note: dmPolicy is "${config.dmPolicy || 'owner'}", set to "allowlist" for this to take effect.`);
     }
-    console.log('Run: pm2 restart zylos-telegram');
   },
 
   'remove-dm-allow': (value) => {
@@ -306,6 +332,34 @@ const commands = {
     }
   },
 
+  'list-members': () => {
+    const map = listMembers();
+    const entries = Object.entries(map);
+    if (entries.length === 0) {
+      console.log('Members cache is empty. Cache fills as users send messages in chats where the bot is present.');
+      return;
+    }
+    console.log(`Members cache (${entries.length} usernames → user_id):`);
+    entries.sort(([a], [b]) => a.localeCompare(b));
+    for (const [username, id] of entries) {
+      console.log(`  @${username}  →  ${id}`);
+    }
+  },
+
+  resolve: (value) => {
+    if (!value) {
+      console.error('Usage: admin.js resolve <@username>');
+      process.exit(1);
+    }
+    const id = resolveUsername(value);
+    if (id) {
+      console.log(`${value} → ${id}`);
+    } else {
+      console.log(`${value} → not in cache (user has not sent a message visible to the bot yet)`);
+      process.exit(1);
+    }
+  },
+
   help: () => {
     console.log(`
 zylos-telegram admin CLI
@@ -319,7 +373,8 @@ Commands:
   remove-group <chat_id>                         Remove group
   set-group-policy <open|allowlist|disabled>     Set global group policy
   set-group-mode <chat_id> <mention|smart>       Set group mode
-  set-group-allowfrom <chat_id> <user_ids...>    Set allowed sender IDs (use * for all)
+  set-group-allowfrom <chat_id> <ids_or_@usernames...>  Set allowed senders (* for all;
+                                                  @username resolved via members cache if seen)
   set-group-history-limit <chat_id> <limit>      Set per-group history limit
 
   DM Access Control:
@@ -334,6 +389,11 @@ Commands:
   remove-whitelist <chat_id|username> <value>    → remove-dm-allow
 
   show-owner                                     Show current owner
+
+  Members Cache (auto-populated from observed messages):
+  list-members                                   Show @username → user_id mappings
+  resolve <@username>                            Look up a single username
+
   help                                           Show this help
 
 Permission flow:

--- a/src/bot.js
+++ b/src/bot.js
@@ -30,6 +30,7 @@ import {
   startPersistInterval,
   persistUserCache
 } from './lib/user-cache.js';
+import { recordMember } from './lib/members.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -431,6 +432,7 @@ bot.on('my_chat_member', (ctx) => {
  * Handle /start command
  */
 bot.start((ctx) => {
+  recordMember(ctx);
   config = loadConfig();
 
   if (!hasOwner(config)) {
@@ -453,6 +455,7 @@ bot.start((ctx) => {
  * Handle text messages
  */
 bot.on('text', (ctx) => {
+  recordMember(ctx);
   if (ctx.message.text.startsWith('/')) return;
   config = loadConfig();
 
@@ -596,6 +599,7 @@ bot.on('text', (ctx) => {
  * Handle photo messages
  */
 bot.on('photo', async (ctx) => {
+  recordMember(ctx);
   const config = loadConfig();
 
   const chatType = ctx.chat.type;
@@ -762,6 +766,7 @@ bot.on('photo', async (ctx) => {
  * Handle document messages
  */
 bot.on('document', async (ctx) => {
+  recordMember(ctx);
   const config = loadConfig();
 
   const chatType = ctx.chat.type;
@@ -928,6 +933,7 @@ bot.on('document', async (ctx) => {
  * Handle voice messages — download and transcribe via local Whisper (Option A: transparent ASR)
  */
 bot.on('voice', async (ctx) => {
+  recordMember(ctx);
   const config = loadConfig();
   const chatType = ctx.chat.type;
   const chatId = ctx.chat.id;

--- a/src/lib/members.js
+++ b/src/lib/members.js
@@ -1,0 +1,135 @@
+/**
+ * Member username → id cache.
+ *
+ * Telegram Bot API has no direct `@username → user_id` resolver for
+ * regular users (only for channels/supergroups). To let the owner say
+ * "allow @user" in natural language and have it resolve to a numeric
+ * user_id, we passively cache mappings observed from incoming messages.
+ *
+ * Schema (flat global map, `~/zylos/components/telegram/members.json`):
+ *
+ *   {
+ *     "<username_lowercase>": "<user_id>",
+ *     ...
+ *   }
+ *
+ * @username is globally unique on Telegram, so the cache is not nested
+ * per-chat. Last-writer-wins on rename / takeover (see USERNAME-TAKEOVER
+ * below).
+ *
+ * Population: `recordMember(ctx)` is called at the top of every message
+ * handler. It captures `ctx.from.id` keyed by `ctx.from.username` for
+ * every user we see. Users without a @username (privacy setting) are
+ * skipped — there is no key to record them under.
+ *
+ * Consumption: `resolveUsername('@felix')` returns the cached numeric id
+ * or null. The admin CLI uses this to translate `@username` arguments to
+ * numeric ids at config-edit time, so the stored allowFrom always uses
+ * stable numeric ids (immune to subsequent username changes).
+ *
+ * USERNAME-TAKEOVER edge case:
+ *   - User A (id 100) is @felix → cache.felix = "100".
+ *   - A renames to @felixnew, A speaks again → cache.felixnew = "100"
+ *     (new entry); cache.felix is still "100" (STALE — A no longer holds
+ *     this @).
+ *   - User B (id 200) claims @felix, B speaks → cache.felix = "200"
+ *     (overwritten — now correct).
+ *   - Window between A renaming and B speaking: `resolveUsername('@felix')`
+ *     still returns "100" (old A). Acceptable: owner can re-issue the
+ *     allow command using the new @ once they notice.
+ *
+ * Writes are debounced (5s) so an active group doesn't thrash disk.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const HOME = process.env.HOME || '/tmp';
+const CACHE_PATH = path.join(HOME, 'zylos/components/telegram/members.json');
+const FLUSH_DEBOUNCE_MS = 5000;
+
+let cache = null;          // in-memory map
+let flushTimer = null;
+let dirty = false;
+
+function loadCache() {
+  if (cache) return cache;
+  try {
+    cache = JSON.parse(fs.readFileSync(CACHE_PATH, 'utf-8')) || {};
+  } catch {
+    cache = {};
+  }
+  return cache;
+}
+
+function scheduleFlush() {
+  dirty = true;
+  if (flushTimer) return;
+  flushTimer = setTimeout(() => {
+    flushTimer = null;
+    if (!dirty) return;
+    dirty = false;
+    try {
+      fs.mkdirSync(path.dirname(CACHE_PATH), { recursive: true });
+      const tmp = `${CACHE_PATH}.tmp.${process.pid}.${Date.now()}`;
+      fs.writeFileSync(tmp, JSON.stringify(cache, null, 2));
+      fs.renameSync(tmp, CACHE_PATH);
+    } catch (err) {
+      console.warn(`[telegram] members cache flush failed: ${err.message}`);
+    }
+  }, FLUSH_DEBOUNCE_MS);
+  flushTimer.unref?.();
+}
+
+/**
+ * Capture username → id mapping from a Telegraf context.
+ * Safe to call at the top of any message handler. No-ops for messages
+ * without ctx.from.username (Telegram users with no public username).
+ */
+export function recordMember(ctx) {
+  const username = ctx?.from?.username;
+  const id = ctx?.from?.id;
+  if (!username || !id) return;
+  const key = String(username).toLowerCase();
+  const val = String(id);
+  const map = loadCache();
+  if (map[key] === val) return;        // no change → skip flush
+  map[key] = val;
+  scheduleFlush();
+}
+
+/**
+ * Resolve `@username` (or bare `username`) to a numeric user_id string.
+ * Returns null if not seen yet.
+ */
+export function resolveUsername(usernameOrAt) {
+  if (!usernameOrAt) return null;
+  const key = String(usernameOrAt).replace(/^@/, '').toLowerCase();
+  return loadCache()[key] || null;
+}
+
+/**
+ * Return the full cache (for admin CLI inspection). Returns a fresh
+ * snapshot — callers must not mutate.
+ */
+export function listMembers() {
+  return { ...loadCache() };
+}
+
+/**
+ * Force-flush pending writes (for shutdown hooks or admin commands that
+ * need the file up-to-date before exiting).
+ */
+export function flushNow() {
+  if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
+  if (!dirty) return;
+  dirty = false;
+  try {
+    fs.mkdirSync(path.dirname(CACHE_PATH), { recursive: true });
+    const tmp = `${CACHE_PATH}.tmp.${process.pid}.${Date.now()}`;
+    fs.writeFileSync(tmp, JSON.stringify(cache, null, 2));
+    fs.renameSync(tmp, CACHE_PATH);
+  } catch (err) {
+    console.warn(`[telegram] members cache flush failed: ${err.message}`);
+  }
+}

--- a/test/members.test.js
+++ b/test/members.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+// Use a per-test HOME dir so the members.json cache file is isolated. The
+// module reads HOME at import time, so we set it BEFORE importing.
+const TEST_HOME = path.join(os.tmpdir(), `zylos-members-test-${Date.now()}-${process.pid}`);
+process.env.HOME = TEST_HOME;
+fs.mkdirSync(path.join(TEST_HOME, 'zylos/components/telegram'), { recursive: true });
+
+const CACHE_PATH = path.join(TEST_HOME, 'zylos/components/telegram/members.json');
+
+// Dynamic import so the module picks up our HOME override
+const { recordMember, resolveUsername, listMembers, flushNow } =
+  await import('../src/lib/members.js');
+
+function clearCache() {
+  try { fs.unlinkSync(CACHE_PATH); } catch {}
+}
+
+describe('members cache', () => {
+  beforeEach(() => {
+    clearCache();
+  });
+
+  afterEach(() => {
+    flushNow();
+    clearCache();
+  });
+
+  it('starts empty when no file exists', () => {
+    expect(listMembers()).toEqual({});
+  });
+
+  it('records username → id from a context', () => {
+    recordMember({ from: { id: 123, username: 'felix' } });
+    expect(resolveUsername('@felix')).toBe('123');
+    expect(resolveUsername('felix')).toBe('123');
+    expect(resolveUsername('@FELIX')).toBe('123');  // case-insensitive
+  });
+
+  it('returns null for unknown usernames', () => {
+    expect(resolveUsername('@nobody')).toBeNull();
+    expect(resolveUsername('')).toBeNull();
+    expect(resolveUsername(undefined)).toBeNull();
+  });
+
+  it('skips users without a username', () => {
+    // Capture cache state, then call recordMember with no username — count
+    // must stay the same (order-independent across earlier tests that may
+    // have populated the singleton cache).
+    const before = Object.keys(listMembers()).length;
+    recordMember({ from: { id: 999 } });
+    recordMember({ from: { id: 999, username: '' } });
+    recordMember({ from: { id: 999, username: null } });
+    expect(Object.keys(listMembers()).length).toBe(before);
+  });
+
+  it('overwrites on takeover: user B claims @felix after user A renames', () => {
+    // A is @felix (id 100)
+    recordMember({ from: { id: 100, username: 'felix' } });
+    expect(resolveUsername('@felix')).toBe('100');
+
+    // A renames to @felixnew, A speaks
+    recordMember({ from: { id: 100, username: 'felixnew' } });
+    expect(resolveUsername('@felixnew')).toBe('100');
+    // Stale: cache.felix still 100 until B speaks
+    expect(resolveUsername('@felix')).toBe('100');
+
+    // B (id 200) now uses @felix, B speaks
+    recordMember({ from: { id: 200, username: 'felix' } });
+    expect(resolveUsername('@felix')).toBe('200');     // overwritten — correct
+    expect(resolveUsername('@felixnew')).toBe('100');  // A still findable by new name
+  });
+
+  it('flushes to disk after debounce window', async () => {
+    recordMember({ from: { id: 42, username: 'alice' } });
+    flushNow();
+    expect(fs.existsSync(CACHE_PATH)).toBe(true);
+    const onDisk = JSON.parse(fs.readFileSync(CACHE_PATH, 'utf-8'));
+    expect(onDisk.alice).toBe('42');
+  });
+
+  it('does not write when the mapping is unchanged', () => {
+    recordMember({ from: { id: 7, username: 'bob' } });
+    flushNow();
+    const mtime1 = fs.statSync(CACHE_PATH).mtimeMs;
+    // Same call → should be a no-op (no dirty flag, no flush)
+    recordMember({ from: { id: 7, username: 'bob' } });
+    flushNow();
+    const mtime2 = fs.statSync(CACHE_PATH).mtimeMs;
+    expect(mtime2).toBe(mtime1);
+  });
+
+  it('strips @ prefix and lowercases the lookup key', () => {
+    recordMember({ from: { id: 11, username: 'MixedCase' } });
+    expect(resolveUsername('@MixedCase')).toBe('11');
+    expect(resolveUsername('@mixedcase')).toBe('11');
+    expect(resolveUsername('mixedcase')).toBe('11');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a passive `@username → user_id` cache so admin commands can accept `@username` arguments for users the bot has previously seen. Closes the gap where Telegram Bot API has no direct username→id resolver for regular users.

## Why

Earlier the only way to authorize a specific user in a group was for the owner to provide their numeric `chat_id` (the bot's runtime had `ctx.from.id` for every observed user but discarded it). With this cache, owner can say `admin.js set-group-allowfrom <chatId> @felix` and the bot resolves `@felix` to the right id, as long as felix has spoken anywhere the bot is present.

## Design (per discussion 2026-06-01)

- **Flat global map** `~/zylos/components/telegram/members.json`:
  ```json
  { "felixl0707": "123456789", "alice99": "987654321" }
  ```
  Usernames are globally unique on Telegram, so no per-group nesting.
- **Population**: `recordMember(ctx)` called at the top of every message handler. Runs before any policy check, so even rejected messages seed the cache. Users without `ctx.from.username` are skipped.
- **Writes**: 5s-debounced + dirty-checked. Active groups don't thrash disk.
- **Username-takeover**: last-writer-wins. If A renames `@x→@y`, the old `cache.x = A` is stale until B claims `@x` (next message overwrites). Stored `allowFrom` uses numeric ids, so existing entries are immune to subsequent renames.

## Files

- `src/lib/members.js` (new, ~140 lines) — `recordMember` / `resolveUsername` / `listMembers` / `flushNow`
- `src/bot.js` — `recordMember(ctx)` at top of `bot.start` / `text` / `photo` / `document` / `voice` handlers + import
- `src/admin.js`:
  - `add-dm-allow @user` and `set-group-allowfrom @user1 @user2 ...` now resolve via cache
  - New: `list-members`, `resolve <@user>`
  - Help text updated
- `hooks/post-upgrade.js` — creates empty `members.json` + prints one-time notice describing the feature
- `CHANGELOG.md` — `[Unreleased]` Added/Changed entries
- `test/members.test.js` (new, 8 tests) — coverage for record / resolve / takeover / debounce / case-insensitive

## Verification

- ✅ `node --check` on all 4 modified files
- ✅ `npm test`: 112/112 pass (8 new)

## Test plan

- [ ] `node admin.js list-members` on a fresh install — shows "empty"
- [ ] Send a few text messages from non-owner users in an authorized group — verify `members.json` populates within ~5s
- [ ] `node admin.js resolve @someone` — verify it returns the right id
- [ ] `node admin.js set-group-allowfrom <chatId> @user` — verify `config.groups[<chatId>].allowFrom` contains the numeric id (not the literal `@user`)
- [ ] `node admin.js set-group-allowfrom <chatId> @neverseen` — verify it stores the literal `@neverseen` with a warning
- [ ] Owner-says-allow flow: user @u1 talks in group → owner runs `set-group-allowfrom <chatId> @u1 <owner-id>` → only u1 and owner can talk to bot
- [ ] After re-installing/upgrading from a previous version: post-upgrade prints the one-time notice and creates an empty `members.json`

## Out of scope (intentionally not done)

- No `new_chat_members` subscription (per owner direction — keep scope tight; bot.js handlers cover ~95% of practically-reachable members)
- No `isAllowedInGroup` change — group filter still strict numeric-id-only; cache-based resolution happens at config-edit time in `admin.js`, so stored allowFrom is always clean numeric ids
- No LRU/TTL/size limit — owner confirmed file size isn't a concern
- No `previous_usernames` history — kept the schema minimal per owner direction (v3 design)