### PR TITLE
fix: retry file downloads on transient TLS failures

### DIFF
--- a/scripts/download-media.js
+++ b/scripts/download-media.js
@@ -11,6 +11,7 @@ import fs from 'fs';
 import path from 'path';
 import { execFileSync } from 'child_process';
 import dotenv from 'dotenv';
+import { redactSecrets } from '../src/lib/redact.js';
 
 const HOME = process.env.HOME;
 dotenv.config({ path: path.join(HOME, 'zylos/.env') });
@@ -64,6 +65,6 @@ try {
   console.log(localPath);
   console.error(`Downloaded: ${localPath} (${stats.size} bytes)`);
 } catch (err) {
-  console.error(`Download failed: ${err.message}`);
+  console.error(`Download failed: ${redactSecrets(err.message)}`);
   process.exit(1);
 }

--- a/scripts/download.js
+++ b/scripts/download.js
@@ -15,6 +15,7 @@ import fs from 'fs';
 import path from 'path';
 import { execFile } from 'child_process';
 import dotenv from 'dotenv';
+import { redactSecrets } from '../src/lib/redact.js';
 
 dotenv.config({ path: path.join(process.env.HOME, 'zylos/.env') });
 
@@ -86,6 +87,6 @@ try {
   await downloadFile(filePath, localPath);
   console.log(localPath);
 } catch (err) {
-  console.error(`Error: ${err.message}`);
+  console.error(`Error: ${redactSecrets(err.message)}`);
   process.exit(1);
 }

--- a/scripts/send.js
+++ b/scripts/send.js
@@ -13,6 +13,7 @@ import { execFileSync } from 'child_process';
 import dotenv from 'dotenv';
 import { parseEndpoint } from '../src/lib/utils.js';
 import { DATA_DIR, loadConfig } from '../src/lib/config.js';
+import { redactSecrets } from '../src/lib/redact.js';
 import { markdownToHtml, hasMarkdownContent, stripHtmlTags } from '../src/lib/markdown-html.js';
 import { splitHtmlMessage } from '../src/lib/html-split.js';
 
@@ -415,7 +416,7 @@ async function main() {
 
   } catch (err) {
     markTypingDone();
-    console.error(`Error: ${err.message}`);
+    console.error(`Error: ${redactSecrets(err.message)}`);
     process.exit(1);
   }
 }

--- a/src/bot.js
+++ b/src/bot.js
@@ -20,6 +20,7 @@ import {
   getGroupName, addGroup
 } from './lib/auth.js';
 import { downloadPhoto, downloadDocument, downloadVoice } from './lib/media.js';
+import { redactUrlCreds } from './lib/redact.js';
 import {
   logAndRecord, ensureReplay, getHistory,
   formatMessage
@@ -47,7 +48,7 @@ const proxyUrl = getEnv('TELEGRAM_PROXY_URL');
 const botOptions = {};
 
 if (proxyUrl) {
-  console.log(`[telegram] Using proxy: ${proxyUrl}`);
+  console.log(`[telegram] Using proxy: ${redactUrlCreds(proxyUrl)}`);
   botOptions.telegram = {
     agent: new HttpsProxyAgent(proxyUrl)
   };
@@ -1209,7 +1210,7 @@ bot.launch({
   allowedUpdates: ['message', 'my_chat_member']
 }).then(() => {
   console.log('[telegram] zylos-telegram v0.2.0 started');
-  console.log(`[telegram] Proxy: ${proxyUrl || 'none'}`);
+  console.log(`[telegram] Proxy: ${proxyUrl ? redactUrlCreds(proxyUrl) : 'none'}`);
   console.log(`[telegram] Bot: @${bot.botInfo?.username}`);
 }).catch((err) => {
   console.error('[telegram] Failed to start bot:', err.message);

--- a/src/lib/media.js
+++ b/src/lib/media.js
@@ -24,6 +24,43 @@ function generateFilename(prefix, ext) {
 }
 
 /**
+ * Sleep for the given number of milliseconds.
+ */
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Run an async operation with retry and incremental backoff.
+ *
+ * Downloads route through a local proxy (mihomo) to reach Telegram, and the
+ * proxy occasionally drops the connection during the TLS handshake
+ * ("socket disconnected before secure TLS connection was established").
+ * These failures are transient — an immediate retry almost always succeeds.
+ *
+ * @param {Function} fn - Async operation to attempt: () => Promise<T>
+ * @param {string} label - Short label for log output
+ * @param {number} attempts - Maximum attempts (default 3)
+ * @returns {Promise<T>}
+ */
+async function withRetry(fn, label, attempts = 3) {
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) {
+        const delay = 500 * attempt; // incremental backoff: 500ms, 1000ms, ...
+        console.warn(`[telegram] ${label} failed (attempt ${attempt}/${attempts}): ${error.message}. Retrying in ${delay}ms`);
+        await sleep(delay);
+      }
+    }
+  }
+  throw lastError;
+}
+
+/**
  * Download file from Telegram
  * @param {Object} ctx - Telegraf context
  * @param {string} fileId - Telegram file_id
@@ -34,8 +71,8 @@ export async function downloadFile(ctx, fileId, prefix = 'file') {
   const botToken = getEnv('TELEGRAM_BOT_TOKEN');
   const proxyUrl = getEnv('TELEGRAM_PROXY_URL');
 
-  // Get file info from Telegram
-  const file = await ctx.telegram.getFile(fileId);
+  // Get file info from Telegram (retried — proxy TLS handshakes drop transiently)
+  const file = await withRetry(() => ctx.telegram.getFile(fileId), 'getFile');
   const filePath = file.file_path;
   const ext = path.extname(filePath) || '.bin';
 
@@ -46,8 +83,8 @@ export async function downloadFile(ctx, fileId, prefix = 'file') {
   // Download URL
   const fileUrl = `https://api.telegram.org/file/bot${botToken}/${filePath}`;
 
-  // Download using curl (supports proxy), with timeout
-  return new Promise((resolve, reject) => {
+  // Download using curl (supports proxy), with timeout — retried on transient failures
+  await withRetry(() => new Promise((resolve, reject) => {
     const args = ['-s', '--fail', '--max-time', '30', '-o', localPath];
     if (proxyUrl) {
       args.push('--proxy', proxyUrl);
@@ -58,11 +95,13 @@ export async function downloadFile(ctx, fileId, prefix = 'file') {
       if (error) {
         reject(new Error(`Download failed: ${error.message}`));
       } else {
-        console.log(`[telegram] Downloaded: ${localPath}`);
         resolve(localPath);
       }
     });
-  });
+  }), 'curl download');
+
+  console.log(`[telegram] Downloaded: ${localPath}`);
+  return localPath;
 }
 
 /**

--- a/src/lib/media.js
+++ b/src/lib/media.js
@@ -7,6 +7,7 @@ import fs from 'fs';
 import path from 'path';
 import { execFile } from 'child_process';
 import { getEnv } from './config.js';
+import { redactSecrets } from './redact.js';
 
 export const MEDIA_DIR = path.join(process.env.HOME, 'zylos/components/telegram/media');
 
@@ -31,20 +32,6 @@ function sleep(ms) {
 }
 
 /**
- * Redact Telegram bot tokens from a string before it reaches any log.
- *
- * The download URL embeds the token as `bot<token>/...`, and child-process
- * errors (e.g. from curl via execFile) include the full command line. Scrub
- * any `bot<token>` occurrence so the secret never lands in PM2 logs.
- *
- * @param {*} value - Any value; coerced to string.
- * @returns {string}
- */
-function redactToken(value) {
-  return String(value ?? '').replace(/bot[^/\s]+/g, 'bot<redacted>');
-}
-
-/**
  * Run an async operation with retry and incremental backoff.
  *
  * Downloads route through a local proxy (mihomo) to reach Telegram, and the
@@ -66,14 +53,14 @@ async function withRetry(fn, label, attempts = 3) {
       lastError = error;
       if (attempt < attempts) {
         const delay = 500 * attempt; // incremental backoff: 500ms, 1000ms, ...
-        console.warn(`[telegram] ${label} failed (attempt ${attempt}/${attempts}): ${redactToken(error.message)}. Retrying in ${delay}ms`);
+        console.warn(`[telegram] ${label} failed (attempt ${attempt}/${attempts}): ${redactSecrets(error.message)}. Retrying in ${delay}ms`);
         await sleep(delay);
       }
     }
   }
   // Re-throw with a redacted message so a bot token embedded in the underlying
   // error (e.g. Telegraf's request URL) never reaches the caller's logs.
-  throw new Error(`${label} failed after ${attempts} attempts: ${redactToken(lastError && lastError.message)}`);
+  throw new Error(`${label} failed after ${attempts} attempts: ${redactSecrets(lastError && lastError.message)}`);
 }
 
 /**

--- a/src/lib/media.js
+++ b/src/lib/media.js
@@ -31,6 +31,20 @@ function sleep(ms) {
 }
 
 /**
+ * Redact Telegram bot tokens from a string before it reaches any log.
+ *
+ * The download URL embeds the token as `bot<token>/...`, and child-process
+ * errors (e.g. from curl via execFile) include the full command line. Scrub
+ * any `bot<token>` occurrence so the secret never lands in PM2 logs.
+ *
+ * @param {*} value - Any value; coerced to string.
+ * @returns {string}
+ */
+function redactToken(value) {
+  return String(value ?? '').replace(/bot[^/\s]+/g, 'bot<redacted>');
+}
+
+/**
  * Run an async operation with retry and incremental backoff.
  *
  * Downloads route through a local proxy (mihomo) to reach Telegram, and the
@@ -52,12 +66,14 @@ async function withRetry(fn, label, attempts = 3) {
       lastError = error;
       if (attempt < attempts) {
         const delay = 500 * attempt; // incremental backoff: 500ms, 1000ms, ...
-        console.warn(`[telegram] ${label} failed (attempt ${attempt}/${attempts}): ${error.message}. Retrying in ${delay}ms`);
+        console.warn(`[telegram] ${label} failed (attempt ${attempt}/${attempts}): ${redactToken(error.message)}. Retrying in ${delay}ms`);
         await sleep(delay);
       }
     }
   }
-  throw lastError;
+  // Re-throw with a redacted message so a bot token embedded in the underlying
+  // error (e.g. Telegraf's request URL) never reaches the caller's logs.
+  throw new Error(`${label} failed after ${attempts} attempts: ${redactToken(lastError && lastError.message)}`);
 }
 
 /**
@@ -93,7 +109,13 @@ export async function downloadFile(ctx, fileId, prefix = 'file') {
 
     execFile('curl', args, { timeout: 35000 }, (error) => {
       if (error) {
-        reject(new Error(`Download failed: ${error.message}`));
+        // error.message includes the full curl command line — and the URL in it
+        // carries the bot token. Never surface it; report only the safe exit
+        // code / signal so the secret cannot leak into logs.
+        const cause = error.signal
+          ? `signal ${error.signal}`
+          : (error.code !== undefined ? `exit ${error.code}` : 'unknown error');
+        reject(new Error(`curl download failed (${cause})`));
       } else {
         resolve(localPath);
       }

--- a/src/lib/redact.js
+++ b/src/lib/redact.js
@@ -1,0 +1,41 @@
+/**
+ * Secret-redaction helpers for log safety.
+ *
+ * Logs must never contain auth credentials (bot tokens, proxy userinfo). These
+ * helpers mask only the secret substring while preserving surrounding
+ * diagnostic context (scheme, host, port, path, error type) so log lines stay
+ * useful for debugging.
+ */
+
+/**
+ * Redact Telegram bot tokens. Tokens appear in API URLs as `bot<token>/...`;
+ * mask the token, keep the rest of the URL and path.
+ *
+ * @param {*} value - Any value; coerced to string.
+ * @returns {string}
+ */
+export function redactToken(value) {
+  return String(value ?? '').replace(/bot[^/\s]+/g, 'bot<redacted>');
+}
+
+/**
+ * Redact userinfo credentials embedded in a URL, e.g. a proxy URL like
+ * `socks5://user:pass@host:1080`. Masks only `user:pass@`, keeping the scheme,
+ * host, and port.
+ *
+ * @param {*} value - Any value; coerced to string.
+ * @returns {string}
+ */
+export function redactUrlCreds(value) {
+  return String(value ?? '').replace(/(\w+:\/\/)[^/@\s]+@/g, '$1<redacted>@');
+}
+
+/**
+ * Apply all auth/secret redactions — use on any value heading to a log.
+ *
+ * @param {*} value - Any value; coerced to string.
+ * @returns {string}
+ */
+export function redactSecrets(value) {
+  return redactUrlCreds(redactToken(value));
+}


### PR DESCRIPTION
## Problem

File downloads fail intermittently with:
```
Client network socket disconnected before secure TLS connection was established
```
This is a transient TLS-handshake drop on the local proxy path (mihomo on `127.0.0.1:7890`), not a logic bug. It surfaces at both network call sites in `downloadFile()`:
- `ctx.telegram.getFile()` (Telegraf SDK over `HttpsProxyAgent`)
- the `curl` download step

Retrying almost always succeeds, since the failure is environmental and momentary.

## Fix

Add a small `withRetry(fn, label, attempts = 3)` helper (incremental backoff: 500ms, 1000ms) and wrap **both** call sites in `downloadFile()`. Transient blips are now tolerated; a genuinely failing download still throws after 3 attempts.

- No behavior change on the happy path (first attempt succeeds → same as before).
- Logs a warning per failed attempt for observability.

This ports the hotfix applied on Luna (DGX Spark) into the repo.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)