### PR TITLE
docs: emphasize exact Telegram command syntax

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -9,6 +9,9 @@ description: >-
   (4) managing group access control (groupPolicy, per-group allowFrom, smart/mention modes),
   (5) configuring the bot (admin CLI, proxy settings),
   (6) troubleshooting Telegram bot connection or polling issues.
+  IMPORTANT: Before sending media or using any command, read this SKILL.md first
+  if you have not loaded the exact syntax in the current session. Do not guess
+  command flags.
   Config at ~/zylos/components/telegram/config.json. Service: pm2 zylos-telegram.
 type: communication
 


### PR DESCRIPTION
## Summary

- add an IMPORTANT reminder to the Telegram skill description
- direct agents to load the exact current-session syntax instead of guessing command flags

## Validation

- frontmatter parsed successfully as YAML
- npm test (104 tests passed)
- git diff --check

Closes #42