### PR TITLE
fix: retry transient Telegram send failures

### DIFF
--- a/scripts/send.js
+++ b/scripts/send.js
@@ -16,6 +16,7 @@ import { DATA_DIR, loadConfig } from '../src/lib/config.js';
 import { redactSecrets } from '../src/lib/redact.js';
 import { markdownToHtml, hasMarkdownContent, stripHtmlTags } from '../src/lib/markdown-html.js';
 import { splitHtmlMessage } from '../src/lib/html-split.js';
+import { withSendRetry } from '../src/lib/send-retry.js';
 
 // Load .env from ~/zylos/.env (not cwd which may be comm-bridge directory)
 dotenv.config({ path: path.join(process.env.HOME, 'zylos/.env') });
@@ -69,7 +70,7 @@ function apiRequest(method, params) {
   if (params.photo || params.document) {
     const filePath = params.photo || params.document;
     const fieldName = params.photo ? 'photo' : 'document';
-    const args = ['-s', '--max-time', '30', '-X', 'POST'];
+    const args = ['-s', '--max-time', '30', '--write-out', '\n%{http_code}', '-X', 'POST'];
     if (PROXY_URL) args.push('--proxy', PROXY_URL);
     args.push(url, '-F', `chat_id=${params.chat_id}`, '-F', `${fieldName}=@${filePath}`);
     if (params.reply_to_message_id) {
@@ -81,37 +82,39 @@ function apiRequest(method, params) {
     result = execFileSync('curl', args, { encoding: 'utf8', timeout: 35000 });
   } else {
     const jsonData = JSON.stringify(params);
-    const textArgs = ['-s', '--max-time', '30', '-X', 'POST', url,
+    const textArgs = ['-s', '--max-time', '30', '--write-out', '\n%{http_code}', '-X', 'POST', url,
       '-H', 'Content-Type: application/json', '-d', jsonData];
     if (PROXY_URL) textArgs.splice(1, 0, '--proxy', PROXY_URL);
     result = execFileSync('curl', textArgs, { encoding: 'utf8', timeout: 35000 });
   }
-  const response = JSON.parse(result);
+  const statusMatch = result.match(/\n(\d{3})$/);
+  if (!statusMatch) {
+    throw new Error('Telegram API response did not include an HTTP status');
+  }
+  const httpStatus = Number(statusMatch[1]);
+  const body = result.slice(0, statusMatch.index);
+
+  let response;
+  try {
+    response = JSON.parse(body);
+  } catch (cause) {
+    const err = new Error(`Telegram API returned invalid JSON (HTTP ${httpStatus})`, { cause });
+    err.httpStatus = httpStatus;
+    throw err;
+  }
   if (response.ok) return response.result;
 
   const err = new Error(response.description || 'API error');
   err.telegramResponse = response;
+  err.httpStatus = httpStatus;
   throw err;
 }
 
 /**
- * API request with 429 retry.
+ * API request with channel-owned transient failure retry.
  */
-async function apiRequestWithRetry(method, params, maxRetries = 2) {
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      return apiRequest(method, params);
-    } catch (err) {
-      const tgErr = err.telegramResponse;
-      if (tgErr?.error_code === 429 && attempt < maxRetries) {
-        const retryAfter = (tgErr.parameters?.retry_after || 5) * 1000;
-        console.warn(`[telegram] Rate limited, retrying in ${retryAfter}ms`);
-        await sleep(retryAfter);
-        continue;
-      }
-      throw err;
-    }
-  }
+function apiRequestWithRetry(method, params) {
+  return withSendRetry(() => apiRequest(method, params));
 }
 
 function splitMessage(text, maxLength) {

--- a/src/lib/send-retry.js
+++ b/src/lib/send-retry.js
@@ -1,0 +1,110 @@
+const RETRYABLE_CURL_EXIT_CODES = new Set([
+  5,  // Could not resolve proxy
+  6,  // Could not resolve host
+  7,  // Failed to connect
+  18, // Partial file
+  28, // Operation timeout
+  35, // TLS handshake failure
+  52, // Empty reply
+  55, // Failed sending data
+  56, // Failed receiving data
+  92, // HTTP/2 stream error
+]);
+
+export const DEFAULT_SEND_RETRY_POLICY = Object.freeze({
+  maxRetries: 2,
+  retryDelayMs: 4000,
+  maxRetryDelayMs: 10000,
+});
+
+/**
+ * Classify a Telegram send failure at the channel boundary.
+ *
+ * @param {Error} err
+ * @returns {{ retryable: boolean, reason: string, retryAfterMs?: number }}
+ */
+export function classifySendError(err) {
+  const telegramCode = Number(err?.telegramResponse?.error_code);
+  const httpStatus = Number(err?.httpStatus);
+
+  if (telegramCode === 429 || httpStatus === 429) {
+    const retryAfterSeconds = Number(err?.telegramResponse?.parameters?.retry_after);
+    return {
+      retryable: true,
+      reason: 'HTTP 429',
+      ...(Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+        ? { retryAfterMs: retryAfterSeconds * 1000 }
+        : {}),
+    };
+  }
+
+  const status = Number.isFinite(telegramCode) && telegramCode > 0
+    ? telegramCode
+    : httpStatus;
+  if (Number.isFinite(status) && status >= 500 && status <= 599) {
+    return { retryable: true, reason: `HTTP ${status}` };
+  }
+  if (Number.isFinite(status) && status >= 400 && status <= 499) {
+    return { retryable: false, reason: `HTTP ${status}` };
+  }
+
+  const curlExitCode = Number(err?.status);
+  if (RETRYABLE_CURL_EXIT_CODES.has(curlExitCode)) {
+    return { retryable: true, reason: `curl exit ${curlExitCode}` };
+  }
+  if (err?.killed || err?.signal === 'SIGTERM') {
+    return { retryable: true, reason: 'curl timeout' };
+  }
+
+  return { retryable: false, reason: 'non-retryable failure' };
+}
+
+/**
+ * Retry a Telegram send while bounding total retry sleep time.
+ *
+ * @template T
+ * @param {() => T | Promise<T>} operation
+ * @param {object} [options]
+ * @param {number} [options.maxRetries]
+ * @param {number} [options.retryDelayMs]
+ * @param {number} [options.maxRetryDelayMs]
+ * @param {(ms: number) => Promise<void>} [options.sleep]
+ * @param {(message: string) => void} [options.log]
+ * @returns {Promise<T>}
+ */
+export async function withSendRetry(operation, options = {}) {
+  const {
+    maxRetries = DEFAULT_SEND_RETRY_POLICY.maxRetries,
+    retryDelayMs = DEFAULT_SEND_RETRY_POLICY.retryDelayMs,
+    maxRetryDelayMs = DEFAULT_SEND_RETRY_POLICY.maxRetryDelayMs,
+    sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
+    log = message => console.warn(message),
+  } = options;
+
+  let retryDelaySpentMs = 0;
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      const classification = classifySendError(err);
+      if (!classification.retryable || attempt >= maxRetries) throw err;
+
+      const delayMs = Math.max(retryDelayMs, classification.retryAfterMs || 0);
+      if (retryDelaySpentMs + delayMs > maxRetryDelayMs) {
+        log(
+          `[telegram] ${classification.reason}; retry skipped because `
+          + `${delayMs}ms would exceed the ${maxRetryDelayMs}ms retry-delay budget`
+        );
+        throw err;
+      }
+
+      log(
+        `[telegram] ${classification.reason}; retrying send `
+        + `(attempt ${attempt + 2}/${maxRetries + 1}) in ${delayMs}ms`
+      );
+      await sleep(delayMs);
+      retryDelaySpentMs += delayMs;
+    }
+  }
+}

--- a/test/send-retry.test.js
+++ b/test/send-retry.test.js
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+import { classifySendError, withSendRetry } from '../src/lib/send-retry.js';
+
+function telegramError(errorCode, retryAfter = null) {
+  const err = new Error(`Telegram error ${errorCode}`);
+  err.telegramResponse = {
+    ok: false,
+    error_code: errorCode,
+    ...(retryAfter == null ? {} : { parameters: { retry_after: retryAfter } }),
+  };
+  err.httpStatus = errorCode;
+  return err;
+}
+
+function curlError(status) {
+  const err = new Error(`curl failed with exit ${status}`);
+  err.status = status;
+  return err;
+}
+
+describe('send failure classification', () => {
+  it('retries transport, HTTP 5xx, and 429 failures', () => {
+    expect(classifySendError(curlError(35))).toMatchObject({ retryable: true, reason: 'curl exit 35' });
+    expect(classifySendError(telegramError(502))).toMatchObject({ retryable: true, reason: 'HTTP 502' });
+    expect(classifySendError(telegramError(429, 5))).toEqual({
+      retryable: true,
+      reason: 'HTTP 429',
+      retryAfterMs: 5000,
+    });
+  });
+
+  it('does not retry non-429 HTTP 4xx or local curl failures', () => {
+    expect(classifySendError(telegramError(400))).toMatchObject({ retryable: false });
+    expect(classifySendError(telegramError(401))).toMatchObject({ retryable: false });
+    expect(classifySendError(curlError(26))).toMatchObject({ retryable: false });
+  });
+});
+
+describe('withSendRetry', () => {
+  it('retries a transport failure at 4-second intervals and logs each retry', async () => {
+    const operation = vi.fn()
+      .mockRejectedValueOnce(curlError(35))
+      .mockRejectedValueOnce(curlError(7))
+      .mockResolvedValue('sent');
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const log = vi.fn();
+
+    await expect(withSendRetry(operation, { sleep, log })).resolves.toBe('sent');
+    expect(operation).toHaveBeenCalledTimes(3);
+    expect(sleep.mock.calls).toEqual([[4000], [4000]]);
+    expect(log).toHaveBeenCalledTimes(2);
+    expect(log.mock.calls[0][0]).toContain('curl exit 35');
+    expect(log.mock.calls[1][0]).toContain('attempt 3/3');
+  });
+
+  it('honors Telegram retry_after when it exceeds the normal interval', async () => {
+    const operation = vi.fn()
+      .mockRejectedValueOnce(telegramError(429, 5))
+      .mockResolvedValue('sent');
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await expect(withSendRetry(operation, { sleep, log: vi.fn() })).resolves.toBe('sent');
+    expect(sleep).toHaveBeenCalledWith(5000);
+  });
+
+  it('retries HTTP 5xx but fails a permanent 4xx immediately', async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const transient = vi.fn()
+      .mockRejectedValueOnce(telegramError(503))
+      .mockResolvedValue('sent');
+    await expect(withSendRetry(transient, { sleep, log: vi.fn() })).resolves.toBe('sent');
+    expect(transient).toHaveBeenCalledTimes(2);
+
+    const permanent = vi.fn().mockRejectedValue(telegramError(403));
+    await expect(withSendRetry(permanent, { sleep, log: vi.fn() })).rejects.toThrow('Telegram error 403');
+    expect(permanent).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops after two retries', async () => {
+    const operation = vi.fn().mockRejectedValue(curlError(56));
+
+    await expect(withSendRetry(operation, {
+      sleep: vi.fn().mockResolvedValue(undefined),
+      log: vi.fn(),
+    })).rejects.toThrow('curl failed with exit 56');
+    expect(operation).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not violate retry_after when it exceeds the total delay budget', async () => {
+    const operation = vi.fn().mockRejectedValue(telegramError(429, 11));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const log = vi.fn();
+
+    await expect(withSendRetry(operation, { sleep, log })).rejects.toThrow('Telegram error 429');
+    expect(operation).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+    expect(log.mock.calls[0][0]).toContain('retry skipped');
+  });
+});


### PR DESCRIPTION
## Summary

- classify retryable curl transport errors, HTTP 5xx, and Telegram 429 responses
- retry at a 4-second interval, at most twice, with a 10-second retry-delay budget
- preserve permanent 4xx handling and existing reply/HTML fallback behavior
- log every retry or budget-based skip

## Validation

- npm test (111 tests passed)
- node --check scripts/send.js
- node --check src/lib/send-retry.js
- git diff --check

Closes #66