### PR TITLE
chore(release): v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-07-10
+
+### Fixed
+- Retry file downloads on transient TLS failures (#65)
+- Retry transient Telegram send failures in `scripts/send.js` — classify-and-retry
+  for curl transport errors, HTTP 5xx, and 429 (honoring `retry_after` within a
+  10s retry-delay budget); other 4xx are not retried; max 2 retries with ~4s
+  interval; each retry is logged (#66, #68)
+
+### Documentation
+- SKILL.md frontmatter now instructs readers to load the exact command syntax
+  from SKILL.md before sending media or using commands — do not guess flags
+  (#42, #67)
+
 ## [0.4.0] - 2026-06-02
 
 ### Changed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: telegram
-version: 0.4.0
+version: 0.4.1
 description: >-
   Telegram Bot communication channel (long polling mode, works behind firewalls).
   Use when: (1) replying to Telegram messages (DM or group @mentions),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-telegram",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-telegram",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-telegram",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Telegram Bot component for Zylos Agent",
   "type": "module",
   "main": "src/bot.js",


### PR DESCRIPTION
## Release v0.4.1

Version bump + CHANGELOG for the v0.4.1 patch release, per the accepted plan for workspace issue 2770f261 (fix #66 + #42, then release).

### Included in this release (already on main)
- `aa11c52` fix: retry file downloads on transient TLS failures (#65)
- `cf88683` fix: retry transient Telegram send failures (#66 → PR #68)
- `d1f7131` docs: emphasize exact Telegram command syntax (#42 → PR #67)

### This PR
- `package.json` version 0.4.0 → 0.4.1
- `SKILL.md` frontmatter version 0.4.0 → 0.4.1
- `CHANGELOG.md` v0.4.1 entry

### Verification
- Post-merge main regression: 111/111 tests green (vitest, merged main d1f7131)
- Re-ran on this branch after bump: 111/111 green

After merge: `gh release create v0.4.1` (will request Howard's approval separately per the no-self-release rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)